### PR TITLE
Fix AtBatGrid mobile view

### DIFF
--- a/reblase/src/components/game/UpdateRow.tsx
+++ b/reblase/src/components/game/UpdateRow.tsx
@@ -20,7 +20,7 @@ const TimestampGrid = "col-start-4 col-end-4 lg:col-start-1 lg:col-end-1";
 const ScoreGrid = "col-start-1 col-end-1 lg:col-start-2 lg:col-end-2";
 const GameLogGrid = "col-start-1 col-end-4 lg:col-start-3 lg:col-end-3";
 const BatterGrid = "col-start-2 col-end-2 justify-self-start lg:col-start-4 lg:col-end-4 lg:justify-self-end";
-const AtBatGrid = "col-start-3 col-end-5 justify-self-end lg:col-start-5 lg:col-end-5";
+const AtBatGrid = "col-span-5 justify-self-end lg:col-start-5 lg:col-end-5";
 const LinkGrid = "hidden lg:block lg:col-start-6 lg:col-end-6";
 
 function Timestamp({ update }: WrappedUpdateProps) {


### PR DESCRIPTION
As more bases/strikes get added, this element gets wider, and runs over BatterGrid. This fix puts it beneath BatterGrid on mobile devices.