### PR TITLE
Dark mode

### DIFF
--- a/reblase/package.json
+++ b/reblase/package.json
@@ -21,6 +21,7 @@
         "react-tooltip": "^4.2.10",
         "swr": "^0.3.1",
         "tailwindcss": "^1.8.6",
+        "tailwindcss-dark-mode": "^1.1.7",
         "twemoji": "^13.0.1"
     },
     "devDependencies": {

--- a/reblase/public/index.html
+++ b/reblase/public/index.html
@@ -6,10 +6,6 @@
         <base href="%PUBLIC_URL%/" />
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-
-        <!-- prevent flash of bright content before scripts load if we're going to be in dark mode anyway -->
-        <style>@media (prefers-color-scheme: dark) { body { background-color: black; }}</style>
-
         <title>Reblase</title>
     </head>
     <body>

--- a/reblase/public/index.html
+++ b/reblase/public/index.html
@@ -6,6 +6,10 @@
         <base href="%PUBLIC_URL%/" />
         <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
         <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+
+        <!-- prevent flash of bright content before scripts load if we're going to be in dark mode anyway -->
+        <style>@media (prefers-color-scheme: dark) { body { background-color: black; }}</style>
+
         <title>Reblase</title>
     </head>
     <body>

--- a/reblase/src/blaseball/color-scheme.ts
+++ b/reblase/src/blaseball/color-scheme.ts
@@ -1,0 +1,28 @@
+const media = window.matchMedia("(prefers-color-scheme: dark)");
+
+function current(): "light" | "dark" {
+    const text = window.localStorage.getItem("color-scheme");
+    if (text === "light" || text === "dark") {
+        return text;
+    }
+    return media.matches ? "dark" : "light";
+}
+
+function update() {
+    if (current() === "dark") {
+        document.documentElement.classList.add("mode-dark");
+    } else {
+        document.documentElement.classList.remove("mode-dark");
+    }
+}
+
+export function setup() {
+    update();
+    media.addListener(update);
+}
+
+export function toggle() {
+    const swap = current() === "light" ? "dark" : "light";
+    window.localStorage.setItem("color-scheme", swap);
+    update();
+}

--- a/reblase/src/blaseball/select.ts
+++ b/reblase/src/blaseball/select.ts
@@ -1,0 +1,28 @@
+import { Theme } from 'react-select';
+
+// Overrides colors in react-select's default theme with CSS custom properties,
+// which are in turn defined in style/style.css, in order to support dark mode.
+export function selectTheme(theme: Theme): Theme {
+    return {
+        ...theme,
+        colors: {
+            primary: 'var(--theme-blue-600)',
+            primary75: 'var(--theme-blue-500)',
+            primary50: 'var(--theme-blue-300)',
+            primary25: 'var(--theme-blue-100)',
+            danger: 'var(--theme-red-600)',
+            dangerLight: 'var(--theme-red-300)',
+            neutral0: 'var(--theme-white)',
+            neutral5: 'var(--theme-gray-100)',
+            neutral10: 'var(--theme-gray-100)',
+            neutral20: 'var(--theme-gray-200)',
+            neutral30: 'var(--theme-gray-300)',
+            neutral40: 'var(--theme-gray-400)',
+            neutral50: 'var(--theme-gray-500)',
+            neutral60: 'var(--theme-gray-600)',
+            neutral70: 'var(--theme-gray-700)',
+            neutral80: 'var(--theme-gray-800)',
+            neutral90: 'var(--theme-gray-900)',
+        }
+    };
+}

--- a/reblase/src/components/elements/BaseDisplay.tsx
+++ b/reblase/src/components/elements/BaseDisplay.tsx
@@ -31,9 +31,9 @@ const Base = (props: {
             />
             <rect
                 strokeWidth="1"
-                stroke="black"
+                stroke="var(--theme-black)"
                 z="1"
-                fill={props.filled ? "black" : "white"}
+                fill={props.filled ? "var(--theme-black)" : "var(--theme-white)"}
                 x={-baseSize / 2}
                 y={-baseSize / 2}
                 width={baseSize}

--- a/reblase/src/components/elements/Circles.tsx
+++ b/reblase/src/components/elements/Circles.tsx
@@ -12,8 +12,8 @@ export function Circles({ amount, total, label }: CirclesProps) {
 
     const radius = 7;
     const radiusInner = 4;
-    const color = "#444";
-    const colorInner = "#111";
+    const color = "var(--theme-gray-700)";
+    const colorInner = "var(--theme-gray-900)";
 
     const circleCount = Math.max(amount, total);
     const circles = [];

--- a/reblase/src/components/elements/Error.tsx
+++ b/reblase/src/components/elements/Error.tsx
@@ -4,7 +4,7 @@ import { FiAlertCircle } from "react-icons/fi";
 export default function Error(props: { children: ReactNode }) {
     return (
         <div
-            className="container mx-auto my-4 bg-red-100 border border-red-300 text-red-700 px-4 py-3 rounded"
+            className="container mx-auto my-4 bg-red-100 dark:bg-red-900 border border-red-300 dark:border-red-700 text-red-700 dark:text-red-100 px-4 py-3 rounded"
             role="alert"
         >
             <FiAlertCircle /> {props.children}

--- a/reblase/src/components/elements/Loading.tsx
+++ b/reblase/src/components/elements/Loading.tsx
@@ -4,7 +4,7 @@ import Spinner from "./Spinner";
 export function Loading() {
     return (
         <div className="my-8 text-lg text-center">
-            <Spinner /> <span className="text-gray-600">Loading...</span>
+            <Spinner /> <span className="text-gray-600 dark:text-gray-400">Loading...</span>
         </div>
     );
 }

--- a/reblase/src/components/elements/OutcomePicker.tsx
+++ b/reblase/src/components/elements/OutcomePicker.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { outcomeTypes } from "../../blaseball/outcome";
+import { selectTheme } from "../../blaseball/select";
 import Twemoji from "./Twemoji";
 import Select from "react-select";
 
@@ -25,6 +26,7 @@ export default function OutcomePicker(props: OutcomePickerProps) {
     return (
         <Select
             options={items}
+            theme={selectTheme}
             isMulti={true}
             placeholder={props.placeholder}
             value={items.filter((item) => (props.selectedOutcomes ?? []).indexOf(item.value) !== -1)}

--- a/reblase/src/components/elements/TeamPicker.tsx
+++ b/reblase/src/components/elements/TeamPicker.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { selectTheme } from "../../blaseball/select";
 import Select from "react-select";
 import { ChronTeam } from "blaseball-lib/chronicler";
 import Twemoji from "./Twemoji";
@@ -26,6 +27,7 @@ export default function TeamPicker(props: TeamPickerProps) {
     return (
         <Select
             options={items}
+            theme={selectTheme}
             isMulti={true}
             placeholder={props.placeholder}
             value={items.filter((item) => (props.selectedTeams ?? []).indexOf(item.value) !== -1)}

--- a/reblase/src/components/elements/WeatherPicker.tsx
+++ b/reblase/src/components/elements/WeatherPicker.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { selectTheme } from "../../blaseball/select";
 import Twemoji from "./Twemoji";
 import Select from "react-select";
 import { allWeatherTypes } from "blaseball-lib/weather";
@@ -27,6 +28,7 @@ export default function WeatherPicker(props: WeatherPickerProps) {
     return (
         <Select
             options={items}
+            theme={selectTheme}
             isMulti={true}
             placeholder={props.placeholder}
             value={items.filter((item) => (props.selectedWeather ?? []).indexOf(item.value) !== -1)}

--- a/reblase/src/components/game/GameUpdateList.tsx
+++ b/reblase/src/components/game/GameUpdateList.tsx
@@ -23,7 +23,7 @@ export function UpdatesListFetching(props: UpdatesListFetchingProps) {
     return (
         <div className="flex flex-col mt-2">
             {props.autoRefresh && (
-                <span className="italic text-gray-600">
+                <span className="italic text-gray-600 dark:text-gray-400">
                     <Spinner /> Live-updating...
                 </span>
             )}

--- a/reblase/src/components/game/UpdateRow.tsx
+++ b/reblase/src/components/game/UpdateRow.tsx
@@ -27,12 +27,12 @@ function Timestamp({ update }: WrappedUpdateProps) {
     const updateTime = dayjs(update.timestamp);
     const time = updateTime.format("mm:ss");
 
-    return <span className={`${TimestampGrid} text-gray-700`}>{time}</span>;
+    return <span className={`${TimestampGrid} text-gray-700 dark:text-gray-300`}>{time}</span>;
 }
 
 function Score({ evt }: UpdateProps) {
     return (
-        <span className={`${ScoreGrid} tag font-semibold bg-gray-200`}>{`${evt.awayScore} - ${evt.homeScore}`}</span>
+        <span className={`${ScoreGrid} tag font-semibold bg-gray-200 dark:bg-gray-800`}>{`${evt.awayScore} - ${evt.homeScore}`}</span>
     );
 }
 
@@ -49,7 +49,7 @@ function Batter({ evt }: UpdateProps) {
         return <span className={`${BatterGrid}`} />;
 
     return (
-        <span className={`${BatterGrid} text-sm bg-gray-200 rounded px-2 py-1 inline-flex items-center justify-center`}>
+        <span className={`${BatterGrid} text-sm bg-gray-200 dark:bg-gray-800 rounded px-2 py-1 inline-flex items-center justify-center`}>
             <Emoji emoji={team.emoji} />
             <span className="ml-1">{team.batterName}</span>
         </span>
@@ -88,7 +88,7 @@ interface UpdateRowProps extends WrappedUpdateProps {
 function UpdateLink(props: { hash: string }) {
     const href = window.location.protocol + "//" + window.location.host + window.location.pathname + "#" + props.hash;
     return (
-        <a href={href} className={`${LinkGrid} -mr-16 pl-4 cursor-pointer text-lg text-gray-500 hover:text-gray-900`}>
+        <a href={href} className={`${LinkGrid} -mr-16 pl-4 cursor-pointer text-lg text-gray-500 hover:text-gray-900 dark-hover:text-gray-100`}>
             <AiOutlineLink />
         </a>
     );
@@ -109,8 +109,8 @@ export const UpdateRow = React.memo(
             <div
                 ref={highlight ? scrollRef : undefined}
                 className={
-                    "grid grid-flow-row-dense gap-2 items-center px-2 py-2 border-b border-gray-300 " +
-                    (highlight ? "bg-yellow-200" : "")
+                    "grid grid-flow-row-dense gap-2 items-center px-2 py-2 border-b border-gray-300 dark:border-gray-700" +
+                    (highlight ? " bg-yellow-200 dark:bg-gray-900" : "")
                 }
                 style={{ gridTemplateColumns: "auto auto 1fr" }}
             >

--- a/reblase/src/components/gamelist/DayTable.tsx
+++ b/reblase/src/components/gamelist/DayTable.tsx
@@ -40,7 +40,7 @@ export const DayTable = function DayTable(props: DayTableProps) {
                 <span className="font-semibold">
                     Season {props.season}, Day {props.day}
                 </span>
-                <span className="flex-1 text-right lg:text-left text-sm text-gray-700">
+                <span className="flex-1 text-right lg:text-left text-sm text-gray-700 dark:text-gray-300">
                     {timestamp?.format("YYYY-MM-DD HH:mm")}
                 </span>
             </div>

--- a/reblase/src/components/gamelist/GameRow.tsx
+++ b/reblase/src/components/gamelist/GameRow.tsx
@@ -11,9 +11,14 @@ const Events = React.memo((props: { outcomes: string[], shame: boolean, awayTeam
     const outcomes = getOutcomes(props.outcomes, props.shame, props.awayTeam);
     if (!outcomes) return <></>;
 
-    const style: Record<string, string> = ["red", "orange", "blue", "pink", "purple", "gray"].reduce((acc, color) => {
-        return { ...acc, [color]: `bg-${color}-200 text-${color}-800 dark:bg-${color}-900 dark:text-${color}-200` };
-    }, {});
+    const style: Record<string, string> = {
+        red: "bg-red-200 dark:bg-red-900 text-red-800 dark:text-red-200",
+        orange: "bg-orange-200 dark:bg-orange-900 text-orange-800 dark:text-orange-200",
+        blue: "bg-blue-200 dark:bg-blue-900 text-blue-800 dark:text-blue-200",
+        pink: "bg-pink-200 dark:bg-pin-900 text-pink-800 dark:text-pin-200",
+        purple: "bg-purple-200 dark:bg-purple-900 text-purple-800 dark:text-purple-200",
+        gray: "bg-gray-200 dark:bg-gray-900 text-gray-800 dark:text-gray-200",
+    };
 
     const outcomesByType: Record<string, Outcome[]> = {};
     for (const outcome of outcomes) {

--- a/reblase/src/components/gamelist/GameRow.tsx
+++ b/reblase/src/components/gamelist/GameRow.tsx
@@ -11,14 +11,9 @@ const Events = React.memo((props: { outcomes: string[], shame: boolean, awayTeam
     const outcomes = getOutcomes(props.outcomes, props.shame, props.awayTeam);
     if (!outcomes) return <></>;
 
-    const style: Record<string, string> = {
-        red: "bg-red-200 text-red-800",
-        orange: "bg-orange-200 text-orange-800",
-        blue: "bg-blue-200 text-blue-800",
-        pink: "bg-pink-200 text-pink-800",
-        purple: "bg-purple-200 text-purple-800",
-        gray: "bg-gray-200 text-gray-800",
-    };
+    const style: Record<string, string> = ["red", "orange", "blue", "pink", "purple", "gray"].reduce((acc, color) => {
+        return { ...acc, [color]: `bg-${color}-200 text-${color}-800 dark:bg-${color}-900 dark:text-${color}-200` };
+    }, {});
 
     const outcomesByType: Record<string, Outcome[]> = {};
     for (const outcome of outcomes) {
@@ -73,7 +68,7 @@ const Duration = React.memo(
         const arrow = props.topOfInning ? "\u25B2" : "\u25BC";
 
         return (
-            <Link className="text-center text-sm tabular-nums text-gray-700" to={`/game/${props.gameId}`}>
+            <Link className="text-center text-sm tabular-nums text-gray-700 dark:text-gray-300" to={`/game/${props.gameId}`}>
                 <span className="w-4 inline-block text-right mr-1">{props.inning + 1}</span>
                 <span className="text-xs pr-2 border-r border-gray-500 mr-2">{arrow}</span>
                 {duration}
@@ -109,7 +104,7 @@ const TeamScoreLine = React.memo((props: { team: TeamData }) => {
             <span className={props.team.win ? "font-semibold" : "font-normal"}>
                 <Twemoji emoji={props.team.emoji} className="mr-1" /> {props.team.name}
             </span>
-            <span className="text-sm text-gray-700 italic">
+            <span className="text-sm text-gray-700 dark:text-gray-300 italic">
                 {props.team.pitcher ? props.team.pitcher : `${props.team.predictedPitcher} (est.)`}
             </span>
         </div>
@@ -132,7 +127,7 @@ const OneLineTeamScore = React.memo((props: { away: TeamData; home: TeamData; cl
                 {props.away.name}
                 <Twemoji emoji={props.away.emoji} className="text-base ml-2" />
             </div>
-            <div className="w-16 text-sm text-center font-semibold bg-gray-200 rounded-sm tabular-nums tracking-tight">
+            <div className="w-16 text-sm text-center font-semibold bg-gray-200 dark:bg-gray-800 rounded-sm tabular-nums tracking-tight">
                 {props.away.score}&ensp;-&ensp;{props.home.score}
             </div>
             <div className={`w-40 text-sm ${props.home.win ? "font-semibold" : "font-normal"}`}>
@@ -152,7 +147,7 @@ const StandalonePitchers = React.memo(
         className?: string;
     }) => {
         return (
-            <div className={`text-sm text-gray-700 italic ${props.className}`}>
+            <div className={`text-sm text-gray-700 dark:text-gray-300 italic ${props.className}`}>
                 {props.awayPitcher ? props.awayPitcher : props.predictedAwayPitcher}
                 {" / "}
                 {props.homePitcher ? props.homePitcher : props.predictedHomePitcher}
@@ -202,7 +197,7 @@ export const GameRow = React.memo(
         return (
             <Link
                 to={`/game/${props.game.gameId}`}
-                className="flex flex-row px-2 py-2 border-b border-gray-300 space-x-2 items-baseline hover:bg-gray-200"
+                className="flex flex-row px-2 py-2 border-b border-gray-300 dark:border-gray-700 space-x-2 items-baseline hover:bg-gray-200 dark-hover:bg-gray-800"
             >
                 <div className="contents md:hidden">
                     <TwoLineTeamScore home={home} away={away} />
@@ -280,7 +275,7 @@ export const FightRow = React.memo(
         return (
             <Link
                 to={`/bossfight/${props.fight.id}`}
-                className="flex flex-row px-2 py-2 border-b border-gray-300 space-x-2 items-baseline hover:bg-gray-200"
+                className="flex flex-row px-2 py-2 border-b border-gray-300 dark:border-gray-700 space-x-2 items-baseline hover:bg-gray-200 dark-hover:bg-gray-800"
             >
                 <div className="contents md:hidden">
                     <TwoLineTeamScore home={home} away={away} />

--- a/reblase/src/components/layout/NavMenu.tsx
+++ b/reblase/src/components/layout/NavMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Container } from "./Container";
+import { toggle as toggleColorScheme } from "../../blaseball/color-scheme";
 
 export function NavMenu() {
     return (
@@ -10,8 +11,15 @@ export function NavMenu() {
                     <div className="flex-1 text-lg font-semibold"><Link to="/">Reblase</Link></div>
 
                     <div className="space-x-8">
+                        <button onClick={toggleColorScheme}>
+                            <span className="dark:hidden">{"\u{1f303}"}<span className="sr-only">Dark mode</span></span>
+                            <span className="hidden dark:inline">{"\u{1f307}"}<span className="sr-only">Light mode</span></span>
+                        </button>
                         <Link to="/seasons">Seasons</Link>
-                        <Link to="/events">Recent events</Link>
+                        <Link to="/events">
+                            <span className="hidden sm:inline">Recent events</span>
+                            <span className="sm:hidden">Events</span>
+                        </Link>
                     </div>
                 </div>
             </Container>

--- a/reblase/src/components/layout/NavMenu.tsx
+++ b/reblase/src/components/layout/NavMenu.tsx
@@ -4,7 +4,7 @@ import { Container } from "./Container";
 
 export function NavMenu() {
     return (
-        <div className="py-4 mb-2 bg-gray-200">
+        <div className="py-4 mb-2 bg-gray-200 dark:bg-gray-800">
             <Container>
                 <div className="flex flex-row">
                     <div className="flex-1 text-lg font-semibold"><Link to="/">Reblase</Link></div>

--- a/reblase/src/components/layout/PageLayout.tsx
+++ b/reblase/src/components/layout/PageLayout.tsx
@@ -8,7 +8,7 @@ export function PageLayout(props: { children: React.ReactNode }) {
 
             {props.children}
 
-            <div className="text-sm text-center my-4 italic text-gray-600">
+            <div className="text-sm text-center my-4 italic text-gray-600 dark:text-gray-400">
                 Brought to you by the {"\u{1f36c}"} Breath Mints.
                 <br />
                 <a href="https://twitter.com/floofstrid">Author</a> (@Ske#6201) |{" "}

--- a/reblase/src/index.js
+++ b/reblase/src/index.js
@@ -2,12 +2,15 @@
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import { setup as setupColorScheme } from "./blaseball/color-scheme";
 
 import "rc-tooltip/assets/bootstrap.css";
 import "./style/style.css";
 
 const baseUrl = document.getElementsByTagName("base")[0].getAttribute("href");
 const rootElement = document.getElementById("root");
+
+setupColorScheme();
 
 ReactDOM.render(
     <BrowserRouter basename={baseUrl}>

--- a/reblase/src/pages/BossfightPage.tsx
+++ b/reblase/src/pages/BossfightPage.tsx
@@ -61,7 +61,7 @@ function BossfightUpdateList(props: { fightUpdates: ChronFightUpdate[]; temporal
     const renderSecondary = (upd: SecondaryUpdate<BossfightSecondary>) => {
         if (upd.data.type === "temporal") {
             return (
-                <div key={upd.timestamp + "_temporal"} className="p-2 border-b border-gray-300">
+                <div key={upd.timestamp + "_temporal"} className="p-2 border-b border-gray-300 dark:border-gray-700">
                     <Twemoji emoji={"\u{1F95C}"} />
                     <span className="ml-2 font-semibold">{upd.data.data.doc?.zeta}</span>
                 </div>
@@ -87,7 +87,7 @@ function BossfightUpdateList(props: { fightUpdates: ChronFightUpdate[]; temporal
                     : upd.data.fight.awayMaxHp
             );
             return (
-                <div key={upd.timestamp + "_damage"} className="p-2 border-b border-gray-300 flex flex-row">
+                <div key={upd.timestamp + "_damage"} className="p-2 border-b border-gray-300 dark:border-gray-700 flex flex-row">
                     <div>
                         <span className="font-semibold">
                             <Twemoji emoji={"\u{1F6A8}"} className="mr-2" />
@@ -96,7 +96,7 @@ function BossfightUpdateList(props: { fightUpdates: ChronFightUpdate[]; temporal
                         took <span className="font-semibold">{upd.data.damage.dmg.toLocaleString()}</span> damage!{" "}
                     </div>
                     <div className="text-right flex-1">
-                        <span className="text-gray-800 mr-1">
+                        <span className="text-gray-800 dark:text-gray-200 mr-1">
                             <Twemoji emoji={teamEmoji} /> {teamHp.toLocaleString()} (
                             {Math.round((teamHp / teamMaxHp) * 100).toLocaleString()}
                             %)

--- a/reblase/src/pages/EventsPage.tsx
+++ b/reblase/src/pages/EventsPage.tsx
@@ -80,7 +80,7 @@ const temporalTypeByGamma: Partial<Record<number, TemporalType>> = {
 
 const EventRow = ({ evt }: { evt: BlaseEvent }) => {
     return (
-        <div className="border-b border-gray-300 py-2">
+        <div className="border-b border-gray-300 dark:border-gray-700 py-2">
             {evt.type === "game" ? (
                 <div className="flex">
                     <Link to={`/game/${evt.game}`} className="text-sm font-semibold flex-1">
@@ -106,7 +106,7 @@ const EventRow = ({ evt }: { evt: BlaseEvent }) => {
                     <ul>
                         {evt.text.map((line, idx) => (
                             <li key={idx}>
-                                <span className="text text-gray-700 tabular-nums mr-2">
+                                <span className="text text-gray-700 dark:text-gray-300 tabular-nums mr-2">
                                     {dayjs(line.timestamp).format("HH:mm")}
                                 </span>
                                 {line.text}
@@ -117,7 +117,7 @@ const EventRow = ({ evt }: { evt: BlaseEvent }) => {
             </p>
 
             {evt.type === "game" && (
-                <span className="text-sm text-gray-700 float-right">
+                <span className="text-sm text-gray-700 dark:text-gray-300 float-right">
                     {evt.awayTeam.nickname} vs. {evt.homeTeam.nickname}
                 </span>
             )}

--- a/reblase/src/pages/Home.tsx
+++ b/reblase/src/pages/Home.tsx
@@ -36,7 +36,7 @@ export function Home() {
 
             <div>
                 <h3 className="text-2xl font-semibold">Current games</h3>
-                <h4 className="text-md text-gray-700 mb-2">
+                <h4 className="text-md text-gray-700 dark:text-gray-300 mb-2">
                     Season {sim.season + 1}, Day {sim.day + 1}
                 </h4>
 

--- a/reblase/src/pages/PlayerUpdatesPage.tsx
+++ b/reblase/src/pages/PlayerUpdatesPage.tsx
@@ -132,10 +132,10 @@ export default function PlayerUpdatesPage() {
                             const changes = prevUpdate && getChangesBetween(prevUpdate.state, state);
                             return (
                                 <tr
-                                    className={`even:bg-gray-100 border-b border-t cursor-pointer ${
+                                    className={`even:bg-gray-100 border-b border-t border-gray-300 dark:border-gray-700 cursor-pointer ${
                                         selectedUpdate === update.id
-                                            ? "bg-blue-500 text-white"
-                                            : "border-gray-300 hover:bg-gray-200"
+                                            ? "bg-blue-500 dark:bg-blue-700 text-white"
+                                            : "hover:bg-gray-200 dark-hover:bg-gray-800"
                                     }`}
                                     onClick={() => setSelectedUpdate(update.id)}
                                 >

--- a/reblase/src/pages/PlayersPage.tsx
+++ b/reblase/src/pages/PlayersPage.tsx
@@ -94,7 +94,7 @@ export function PlayersPage() {
                             {attrs.map((a) => {
                                 const text = display[a] ?? a;
                                 return (
-                                    <span key={a} className="tag tag-sm bg-gray-300">
+                                    <span key={a} className="tag tag-sm bg-gray-300 dark:bg-gray-700">
                                         {text}
                                     </span>
                                 );
@@ -136,7 +136,7 @@ export function PlayersPage() {
         <Container>
             <table {...table.getTableProps()}>
                 <thead>
-                    <tr className="bg-gray-100 border-b border-gray-300">
+                    <tr className="bg-gray-100 dark:bg-gray-900 border-b border-gray-300 dark:border-gray-700">
                         {(table.allColumns as (ColumnInstance<ChronPlayer> & UseSortByColumnProps<ChronPlayer>)[]).map(
                             (column) => (
                                 <th className="px-4 py-2" {...column.getHeaderProps(column.getSortByToggleProps())}>
@@ -151,7 +151,7 @@ export function PlayersPage() {
                     {table.rows.map((row) => {
                         table.prepareRow(row);
                         return (
-                            <tr className="border-t border-b border-gray-300" {...row.getRowProps()}>
+                            <tr className="border-t border-b border-gray-300 dark:border-gray-700" {...row.getRowProps()}>
                                 {row.cells.map((cell) => {
                                     return (
                                         <td

--- a/reblase/src/pages/SeasonListPage.tsx
+++ b/reblase/src/pages/SeasonListPage.tsx
@@ -19,11 +19,11 @@ function SeasonRow(props: { game: ChronGame }) {
     const target = `/season/${displaySeasonNumber}`;
     return (
         <Link
-            className="flex px-4 py-2 border-b border-solid border-gray-300 items-center hover:bg-gray-200"
+            className="flex px-4 py-2 border-b border-solid border-gray-300 dark:border-gray-700 items-center hover:bg-gray-200 dark-hover:bg-gray-800"
             to={target}
         >
             <span className="text-lg font-semibold">Season {displaySeasonNumber}</span>
-            <span className="text-gray-700 ml-4 mr-auto">
+            <span className="text-gray-700 dark:text-gray-300 ml-4 mr-auto">
                 {startDate?.format(dateFormat) ?? "TBD"} - {endDate?.format(dateFormat) ?? "TBD"}
             </span>
             <span className="text-semibold">View games</span>

--- a/reblase/src/style/style.css
+++ b/reblase/src/style/style.css
@@ -28,26 +28,24 @@
         @apply bg-white text-gray-900 antialiased min-h-screen;
     }
 
-    @screen dark {
-        :root {
-            --theme-black: theme("colors.white");
-            --theme-white: theme("colors.black");
-            --theme-gray-100: theme("colors.gray.900");
-            --theme-gray-200: theme("colors.gray.800");
-            --theme-gray-300: theme("colors.gray.700");
-            --theme-gray-400: theme("colors.gray.600");
-            --theme-gray-500: theme("colors.gray.500");
-            --theme-gray-600: theme("colors.gray.400");
-            --theme-gray-700: theme("colors.gray.300");
-            --theme-gray-800: theme("colors.gray.200");
-            --theme-gray-900: theme("colors.gray.100");
-            --theme-blue-600: theme("colors.blue.400");
-            --theme-blue-500: theme("colors.blue.500");
-            --theme-blue-300: theme("colors.blue.700");
-            --theme-blue-100: theme("colors.blue.900");
-            --theme-red-600: theme("colors.red.200");
-            --theme-red-300: theme("colors.red.700");
-        }
+    :root.mode-dark {
+        --theme-black: theme("colors.white");
+        --theme-white: theme("colors.black");
+        --theme-gray-100: theme("colors.gray.900");
+        --theme-gray-200: theme("colors.gray.800");
+        --theme-gray-300: theme("colors.gray.700");
+        --theme-gray-400: theme("colors.gray.600");
+        --theme-gray-500: theme("colors.gray.500");
+        --theme-gray-600: theme("colors.gray.400");
+        --theme-gray-700: theme("colors.gray.300");
+        --theme-gray-800: theme("colors.gray.200");
+        --theme-gray-900: theme("colors.gray.100");
+        --theme-blue-600: theme("colors.blue.400");
+        --theme-blue-500: theme("colors.blue.500");
+        --theme-blue-300: theme("colors.blue.700");
+        --theme-blue-100: theme("colors.blue.900");
+        --theme-red-600: theme("colors.red.200");
+        --theme-red-300: theme("colors.red.700");
 
         body {
             @apply bg-black text-gray-100;

--- a/reblase/src/style/style.css
+++ b/reblase/src/style/style.css
@@ -3,8 +3,55 @@
 @tailwind utilities;
 
 @layer base {
+    /* See blaseball/select.ts :( */
+    :root {
+        --theme-black: theme("colors.black");
+        --theme-white: theme("colors.white");
+        --theme-gray-100: theme("colors.gray.100");
+        --theme-gray-200: theme("colors.gray.200");
+        --theme-gray-300: theme("colors.gray.300");
+        --theme-gray-400: theme("colors.gray.400");
+        --theme-gray-500: theme("colors.gray.500");
+        --theme-gray-600: theme("colors.gray.600");
+        --theme-gray-700: theme("colors.gray.700");
+        --theme-gray-800: theme("colors.gray.800");
+        --theme-gray-900: theme("colors.gray.900");
+        --theme-blue-600: theme("colors.blue.600");
+        --theme-blue-500: theme("colors.blue.500");
+        --theme-blue-300: theme("colors.blue.300");
+        --theme-blue-100: theme("colors.blue.100");
+        --theme-red-600: theme("colors.red.600");
+        --theme-red-300: theme("colors.red.300");
+    }
+
     body {
-        @apply text-gray-900 antialiased min-h-screen;
+        @apply bg-white text-gray-900 antialiased min-h-screen;
+    }
+
+    @screen dark {
+        :root {
+            --theme-black: theme("colors.white");
+            --theme-white: theme("colors.black");
+            --theme-gray-100: theme("colors.gray.900");
+            --theme-gray-200: theme("colors.gray.800");
+            --theme-gray-300: theme("colors.gray.700");
+            --theme-gray-400: theme("colors.gray.600");
+            --theme-gray-500: theme("colors.gray.500");
+            --theme-gray-600: theme("colors.gray.400");
+            --theme-gray-700: theme("colors.gray.300");
+            --theme-gray-800: theme("colors.gray.200");
+            --theme-gray-900: theme("colors.gray.100");
+            --theme-blue-600: theme("colors.blue.400");
+            --theme-blue-500: theme("colors.blue.500");
+            --theme-blue-300: theme("colors.blue.700");
+            --theme-blue-100: theme("colors.blue.900");
+            --theme-red-600: theme("colors.red.200");
+            --theme-red-300: theme("colors.red.700");
+        }
+
+        body {
+            @apply bg-black text-gray-100;
+        }
     }
 
     strong {

--- a/reblase/tailwind.config.js
+++ b/reblase/tailwind.config.js
@@ -1,6 +1,4 @@
-﻿const plugin = require("tailwindcss/plugin")
-
-module.exports = {
+﻿module.exports = {
     purge: ["src/**/*.tsx", "src/**/*.html", "src/**/*.ts"],
     theme: {
         screens: {
@@ -9,25 +7,15 @@ module.exports = {
             lg: "1024px",
             xl: "1200px",
         },
-        extend: {
-            screens: { dark: { raw: "(prefers-color-scheme: dark)" } },
-        },
     },
     variants: {
-        backgroundColor: ["responsive", "odd", "hover", "dark-hover", "focus"],
-        textColor: ["responsive", "dark-hover"],
+        backgroundColor: ({ after }) => after(["odd", "dark", "dark-hover"]),
+        borderColor: ({ after }) => after(["dark"]),
+        display: ({ after }) => after(["dark"]),
+        textColor: ({ after }) => after(["dark", "dark-hover"]),
     },
     plugins: [
-        plugin(function({ addVariant, e, postcss }) {
-            addVariant("dark-hover", ({ container, separator }) => {
-                const mediaRule = postcss.atRule({ name: "media", params: "(prefers-color-scheme: dark)" });
-                mediaRule.append(container.nodes);
-                container.append(mediaRule);
-                mediaRule.walkRules(rule => {
-                    rule.selector = `.${e(`dark-hover${separator}${rule.selector.slice(1)}`)}:hover`;
-                });
-            });
-        }),
+        require('tailwindcss-dark-mode')(),
     ],
     future: {
         removeDeprecatedGapUtilities: true,

--- a/reblase/tailwind.config.js
+++ b/reblase/tailwind.config.js
@@ -1,4 +1,6 @@
-﻿module.exports = {
+﻿const plugin = require("tailwindcss/plugin")
+
+module.exports = {
     purge: ["src/**/*.tsx", "src/**/*.html", "src/**/*.ts"],
     theme: {
         screens: {
@@ -7,12 +9,26 @@
             lg: "1024px",
             xl: "1200px",
         },
-        extend: {},
+        extend: {
+            screens: { dark: { raw: "(prefers-color-scheme: dark)" } },
+        },
     },
     variants: {
-        backgroundColor: ["responsive", "odd", "hover", "focus"],
+        backgroundColor: ["responsive", "odd", "hover", "dark-hover", "focus"],
+        textColor: ["responsive", "dark-hover"],
     },
-    plugins: [],
+    plugins: [
+        plugin(function({ addVariant, e, postcss }) {
+            addVariant("dark-hover", ({ container, separator }) => {
+                const mediaRule = postcss.atRule({ name: "media", params: "(prefers-color-scheme: dark)" });
+                mediaRule.append(container.nodes);
+                container.append(mediaRule);
+                mediaRule.walkRules(rule => {
+                    rule.selector = `.${e(`dark-hover${separator}${rule.selector.slice(1)}`)}:hover`;
+                });
+            });
+        }),
+    ],
     future: {
         removeDeprecatedGapUtilities: true,
         purgeLayersByDefault: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8713,6 +8713,16 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
+postcss-selector-parser@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
+  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
+  dependencies:
+    cssesc "^3.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+    util-deprecate "^1.0.2"
+
 postcss-svgo@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
@@ -10514,10 +10524,46 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tailwindcss-dark-mode@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/tailwindcss-dark-mode/-/tailwindcss-dark-mode-1.1.7.tgz#b9b1a49fed12601826c6b6b7e9f98170e4b14abf"
+  integrity sha512-RGYAlOJq4VynCy7LRAIJPHHvV1E3wivMD+K2njVlqIJsegqAZSGIOYnlQwNnkYrQCdFcNZj/ygzplB4y4mYITg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+    tailwindcss "^1.9.2"
+
 tailwindcss@^1.8.6:
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.8.6.tgz#7ec08777d6cc50bd79e9bedf381f1f10f132bdd5"
   integrity sha512-iUbDjwkBdbY+9hlVfuHRXJN3lC7h4Fc4Vz/YqjMMeL0AeCH73MMgVDmto0ulCzh1KM1sv0VV9WmV0bcDMgw5Tw==
+  dependencies:
+    "@fullhuman/postcss-purgecss" "^2.1.2"
+    autoprefixer "^9.4.5"
+    browserslist "^4.12.0"
+    bytes "^3.0.0"
+    chalk "^3.0.0 || ^4.0.0"
+    color "^3.1.2"
+    detective "^5.2.0"
+    fs-extra "^8.0.0"
+    html-tags "^3.1.0"
+    lodash "^4.17.20"
+    node-emoji "^1.8.1"
+    normalize.css "^8.0.1"
+    object-hash "^2.0.3"
+    postcss "^7.0.11"
+    postcss-functions "^3.0.0"
+    postcss-js "^2.0.0"
+    postcss-nested "^4.1.1"
+    postcss-selector-parser "^6.0.0"
+    postcss-value-parser "^4.1.0"
+    pretty-hrtime "^1.0.3"
+    reduce-css-calc "^2.1.6"
+    resolve "^1.14.2"
+
+tailwindcss@^1.9.2:
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
+  integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==
   dependencies:
     "@fullhuman/postcss-purgecss" "^2.1.2"
     autoprefixer "^9.4.5"
@@ -10970,7 +11016,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
This adds automatic dark mode support based on [`@media (prefers-color-scheme: dark)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).

For the most part, this was just adding the [`dark` breakpoint](https://tailwindcss.com/docs/breakpoints#dark-mode) and adding the necessary classes everywhere. Breakpoints can't be combined in this way, so I wrote a small plugin to handle `dark-hover:`.

`react-select` is a bit of a pain in the ass to customize colors for, but it works.

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/52814/97079568-eb85c180-15a9-11eb-8b27-b11548ffb61b.png)
![image](https://user-images.githubusercontent.com/52814/97079608-53d4a300-15aa-11eb-9ab6-e8d10a0778f9.png)
![Screenshot from 2020-10-24 03-37-01](https://user-images.githubusercontent.com/52814/97079616-64851900-15aa-11eb-90f2-01c2c5935645.png)
![Screenshot from 2020-10-24 03-36-45](https://user-images.githubusercontent.com/52814/97079617-651daf80-15aa-11eb-992b-79bbabea702a.png)
![Screenshot from 2020-10-24 03-36-01](https://user-images.githubusercontent.com/52814/97079618-65b64600-15aa-11eb-9752-da80f23cd0ac.png)

</details>