### PR TITLE
Initial box score work

### DIFF
--- a/blaseball-lib/chronicler.ts
+++ b/blaseball-lib/chronicler.ts
@@ -6,6 +6,9 @@ import {
     BlaseballSimData,
     BlaseballTeam,
     BlaseballTemporal,
+    BlaseballGameStats,
+    BlaseballTeamStats,
+    BlaseballPlayerStats,
 } from "./models";
 
 export const BASE_URL = process.env.REACT_APP_SIBR_API ?? "/";
@@ -13,6 +16,7 @@ export const BASE_URL = process.env.REACT_APP_SIBR_API ?? "/";
 export const chroniclerApi = {
     gameList: (query: GameListQuery) => BASE_URL + "/games?" + queryString.stringify(query),
     gameUpdates: (query: GameUpdatesQuery) => BASE_URL + "/games/updates?" + queryString.stringify(query),
+    gameStats: (query: GameStatsQuery) => BASE_URL + "/games/stats?" + queryString.stringify(query),
     fights: () => BASE_URL + "/fights",
     fightUpdates: (query: FightUpdatesQuery) => BASE_URL + "/fights/updates?" + queryString.stringify(query),
     players: () => BASE_URL + "/players",
@@ -46,6 +50,10 @@ export type GameUpdatesQuery = {
     count?: number;
 };
 
+export type GameStatsQuery = {
+    game: string;
+};
+
 export type FightUpdatesQuery = {
     fight: string;
     after?: string;
@@ -67,6 +75,7 @@ export interface PagedResponse {
 
 export interface GameListResponse extends ChronResponse<ChronGame> {}
 export interface GameUpdatesResponse extends ChronResponse<ChronGameUpdate>, PagedResponse {}
+export interface GameStatsResponse extends ChronResponse<ChronGameStats> {}
 export interface FightUpdatesResponse extends ChronResponse<ChronFightUpdate>, PagedResponse {}
 export interface FightsResponse extends ChronResponse<ChronFight> {}
 export interface PlayersResponse extends ChronResponse<ChronPlayer> {}
@@ -89,6 +98,14 @@ export interface ChronGameUpdate {
     hash: string;
     timestamp: Timestamp;
     data: BlaseballGame;
+}
+
+export interface ChronGameStats {
+    gameId: string;
+    timestamp: Timestamp;
+    gameStats: BlaseballGameStats;
+    teamStats: BlaseballTeamStats[];
+    playerStats: BlaseballPlayerStats[];
 }
 
 export interface ChronFightUpdate {

--- a/blaseball-lib/common.ts
+++ b/blaseball-lib/common.ts
@@ -7,6 +7,9 @@ export type SubleagueID = string;
 export type DivisionID = string;
 export type SeasonID = string;
 export type PlayoffsID = string;
+export type GameStatsheetID = string;
+export type TeamStatsheetID = string;
+export type PlayerStatsheetID = string;
 
 export interface BlaseballEntity<T> {
     id?: T;

--- a/blaseball-lib/models.ts
+++ b/blaseball-lib/models.ts
@@ -4,13 +4,16 @@ import {
     BlaseballAttributesDeprecated,
     BlaseballEntity,
     GameID,
+    GameStatsheetID,
     LeagueID,
     PlayerID,
     PlayerStats,
+    PlayerStatsheetID,
     PlayoffsID,
     SeasonID,
     TeamID,
     TeamRoster,
+    TeamStatsheetID,
 } from "./common";
 
 export interface BlaseballGame extends BlaseballEntity<GameID> {
@@ -190,4 +193,47 @@ export interface BlaseballSimData extends BlaseballEntity<"thisidisstaticyo"> {
     doTheThing?: boolean;
     eatTheRich?: boolean;
     unlockedInterviews?: boolean;
+}
+
+export interface BlaseballGameStats extends BlaseballEntity<GameStatsheetID> {
+    awayTeamRunsByInning: number[];
+    homeTeamRunsByInning: number[];
+    awayTeamStats: TeamStatsheetID;
+    homeTeamStats: TeamStatsheetID;
+}
+
+export interface BlaseballTeamStats extends BlaseballEntity<TeamStatsheetID> {
+    playerStats: PlayerStatsheetID[];
+    name: string;
+    teamId: TeamID;
+}
+
+export interface BlaseballPlayerStats extends BlaseballEntity<PlayerStatsheetID> {
+    playerId?: PlayerID;
+    teamId?: TeamID;
+    team: string,
+    name: string,
+    atBats?: number,
+    caughtStealing?: number,
+    doubles?: number,
+    earnedRuns?: number,
+    groundIntoDp?: number,
+    hits?: number,
+    hitsAllowed?: number,
+    homeRuns?: number,
+    losses?: number,
+    outsRecorded?: number,
+    rbis?: number,
+    runs?: number,
+    stolenBases?: number,
+    strikeouts?: number,
+    struckouts?: number,
+    triples?: number,
+    walks?: number,
+    walksIssued?: number,
+    wins?: number,
+    hitByPitch?: number,
+    hitBatters?: number,
+    quadruples?: number,
+    pitchesThrown?: number,
 }

--- a/reblase/src/blaseball/hooks.ts
+++ b/reblase/src/blaseball/hooks.ts
@@ -2,6 +2,7 @@ import useSWR from "swr";
 import { useEffect, useMemo, useState } from "react";
 import {
     ChronGame,
+    ChronGameStats,
     ChronGameUpdate,
     ChronPlayer,
     ChronResponse,
@@ -9,6 +10,8 @@ import {
     ChronTemporalUpdate,
     GameListQuery,
     GameListResponse,
+    GameStatsQuery,
+    GameStatsResponse,
     GameUpdatesQuery,
     GameUpdatesResponse,
     chroniclerApi,
@@ -81,6 +84,22 @@ export function useGameUpdates(query: GameUpdatesQuery, autoRefresh: boolean): G
         updates: allUpdates,
         isLoading: !initialData,
         error,
+    };
+}
+
+interface GameStatsHookReturn {
+    stats: ChronGameStats[];
+    error: any;
+    isLoading: boolean;
+}
+
+export function useGameStats(query: GameStatsQuery): GameStatsHookReturn {
+    const { data, error } = useSWR<GameStatsResponse>(chroniclerApi.gameStats(query));
+
+    return {
+        stats: data?.data ?? [],
+        error,
+        isLoading: !data,
     };
 }
 

--- a/reblase/src/components/game/BoxScore.tsx
+++ b/reblase/src/components/game/BoxScore.tsx
@@ -1,0 +1,99 @@
+import React, { ReactNode } from "react";
+
+import Emoji from "../elements/Emoji";
+import { ChronGameStats } from "blaseball-lib/chronicler";
+import { BlaseballGame, BlaseballGameStats, BlaseballTeamStats, BlaseballPlayerStats } from "blaseball-lib/models";
+import Error from "components/elements/Error";
+import { Loading } from "components/elements/Loading";
+
+interface Stats {
+    gameStats: BlaseballGameStats,
+    teamStats?: BlaseballTeamStats,
+    playerStats: BlaseballPlayerStats[],
+}
+
+function filterStats(stats: ChronGameStats, away: boolean): Stats {
+    const teamStats = stats.teamStats.find(
+        (sheet) => sheet.id === stats.gameStats[away ? "awayTeamStats" : "homeTeamStats"]);
+    const playerStats = stats.playerStats.filter((sheet) => teamStats?.playerStats.some((id) => sheet.id === id));
+    return { ...stats, teamStats, playerStats };
+}
+
+function DataCell(props: { children: ReactNode, header?: boolean, classes?: string[], bold?: boolean }) {
+    const Tag = props.header ? "th" : "td";
+    const className = [
+        props.bold ? "font-bold" : "font-normal",
+        "text-center", "px-4", "py-2",
+        "border", "border-gray-300", "dark:border-gray-700",
+        ...(props.classes ?? [])
+    ].join(" ");
+    return <Tag className={className}>{props.children}</Tag>;
+}
+
+function HeaderCell(props: { children: ReactNode, classes?: string[], bold?: boolean }) {
+    return (
+        <DataCell
+            {...props}
+            classes={["bg-gray-200", "dark:bg-gray-800", ...(props.classes ?? [])]}
+            header={true}
+        >
+            {props.children}
+        </DataCell>
+    );
+}
+
+function TopRow(props: { innings: number }) {
+    return (
+        <tr>
+            <HeaderCell>&nbsp;</HeaderCell>
+            {[...Array(props.innings)].map((_, idx) => <HeaderCell classes={["w-12"]}>{idx + 1}</HeaderCell>)}
+            <HeaderCell bold={true} classes={["w-12"]}><abbr title="Runs">R</abbr></HeaderCell>
+            <HeaderCell bold={true} classes={["w-12"]}><abbr title="Hits">H</abbr></HeaderCell>
+        </tr>
+    );
+}
+
+function ScoreRow(props: { game: BlaseballGame, stats: ChronGameStats, innings: number, away: boolean }) {
+    const { game, stats, innings, away } = props;
+    const { gameStats, playerStats } = filterStats(stats, away);
+
+    const emoji = game[away ? "awayTeamEmoji" : "homeTeamEmoji"];
+    const name = game[away ? "awayTeamName" : "homeTeamName"];
+    const won = game.gameComplete && game[away ? "awayScore" : "homeScore"] > game[away ? "homeScore" : "awayScore"];
+    const runsByInning = gameStats[away ? "awayTeamRunsByInning" : "homeTeamRunsByInning"];
+
+    return (
+        <tr>
+            <HeaderCell bold={won}><Emoji emoji={emoji} /> {name}</HeaderCell>
+            {[...Array(innings)].map((_, idx) => <DataCell>{runsByInning[idx] ?? (game.gameComplete ? "X" : null)}</DataCell>)}
+            <DataCell bold={true}>{runsByInning.reduce((acc, n) => acc + n, 0)}</DataCell>
+            <DataCell bold={true}>{playerStats.reduce((acc, sheet) => acc + (sheet.hits ?? 0), 0)}</DataCell>
+        </tr>
+    );
+}
+
+interface BoxScoreProps {
+    game: BlaseballGame;
+    stats: ChronGameStats[];
+    error: any;
+    isLoading: boolean;
+}
+
+export function BoxScore(props: BoxScoreProps) {
+    if (props.error) return <Error>{props.error.toString()}</Error>;
+
+    const stats = props.stats[props.stats.length - 1];
+    if (stats === undefined) return props.isLoading ? <Loading /> : null;
+
+    const game = props.game;
+    const innings = Math.max(9, stats.gameStats.awayTeamRunsByInning.length);
+
+    return (
+        <table className="Boxscore table-fixed m-auto mt-4">
+            <tbody>
+                <TopRow innings={innings} />
+                {[true, false].map((away) => <ScoreRow game={game} stats={stats} innings={innings} away={away} />)}
+            </tbody>
+        </table>
+    );
+}

--- a/reblase/src/pages/GamePage.tsx
+++ b/reblase/src/pages/GamePage.tsx
@@ -2,9 +2,10 @@ import React, { ReactNode, useEffect, useState } from "react";
 import { useParams, useLocation } from "react-router";
 
 import { UpdatesListFetching } from "../components/game/GameUpdateList";
+import { BoxScore } from "../components/game/BoxScore";
 import { cache } from "swr";
 import Error from "../components/elements/Error";
-import { useGameUpdates } from "../blaseball/hooks";
+import { useGameStats, useGameUpdates } from "../blaseball/hooks";
 import { BlaseballGame } from "blaseball-lib/models";
 import { Link } from "react-router-dom";
 import { displaySeason } from "blaseball-lib/games";
@@ -108,6 +109,7 @@ export function GamePage() {
         started: true,
     };
     const { updates, error, isLoading } = useGameUpdates(query, options.autoUpdate);
+    const gameStats = useGameStats({ game: gameId ?? "null" });
     if (error) return <Error>{error.toString()}</Error>;
 
     const last = updates[updates.length - 1]?.data;
@@ -120,6 +122,8 @@ export function GamePage() {
             {last && <GameHeading evt={last} />}
 
             <GamePageOptions options={options} setOptions={setOptions} gameComplete={last?.gameComplete ?? true} />
+
+            {last && <BoxScore game={last} {...gameStats} />}
 
             <UpdatesListFetching
                 updates={updates}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52814/105228047-f3a4bd00-5b16-11eb-8a0f-efe1da6db767.png)

Requires landing and deploying https://github.com/xSke/Chronicler/pull/1.

This _should_ work correctly when games are in-progress, but doesn't auto-update. Not sure how I want to add that, because hitting the `games/stats` endpoint every 2 seconds is a bit more load than hitting the `games/updates` endpoint every 2 seconds.

Tested that this works on games where statsheets aren't loaded in Chronicler for a game (it just doesn't show the line score).

Future work: I'd like to make an expandable (hidden-by-default) part of the table that shows the full box score (per-player stats and also the game event list).