### PR TITLE
List Exhibitions in separate grouping

### DIFF
--- a/reblase/src/pages/SeasonListPage.tsx
+++ b/reblase/src/pages/SeasonListPage.tsx
@@ -57,9 +57,15 @@ export function SeasonListPage() {
         <Container className={"mt-4"}>
             <h2 className="text-2xl font-semibold mb-2">Seasons</h2>
 
+            <div className="flex flex-col mb-6">
+                {seasonsList.map((seasonGame, i) => (
+                    seasonGame.data.season >= 0 ? <SeasonRow key={i} game={seasonGame}/> : null
+                ))}
+            </div>
+            <h2 className="text-2xl font-semibold mb-2">Exhibitions</h2>
             <div className="flex flex-col">
                 {seasonsList.map((seasonGame, i) => (
-                    <SeasonRow key={i} game={seasonGame}></SeasonRow>
+                    seasonGame.data.season < 0 ? <SeasonRow key={i} game={seasonGame}/> : null
                 ))}
             </div>
         </Container>


### PR DESCRIPTION
This is a minor change to the way Seasons are listed on `/seasons`, moving exhibition-type seasons (e.g., the Coffee Cup) to a separate list, preventing them from displaying in the most recent position of the Seasons list, as they do on live currently.

In terms of looking toward future shenanigans, this change assumes that future exhibitions will continue to be given season numbers below 0, and that Reblase will continue to use current sorting function as-is to determine ordering.