### PR TITLE
Change black hole regexes to handle burping

### DIFF
--- a/blaseball-lib/games.ts
+++ b/blaseball-lib/games.ts
@@ -170,7 +170,7 @@ export function isGameUpdateImportant(update: string, scoreUpdate: string | null
         /murder of Crows/,
         /charms/,
         /Sun 2 smiles/,
-        /Black Hole swallows/,
+        /Black Hole swallow/,
         /is Beaned by/,
         /is Percolated/,
         /tastes the infinite/,

--- a/reblase/src/blaseball/outcome.ts
+++ b/reblase/src/blaseball/outcome.ts
@@ -28,7 +28,7 @@ export const outcomeTypes: OutcomeType[] = [
     { name: "Birds", emoji: "\u{1F426}", search: [/The Birds pecked/i], color: "purple" },
     { name: "Peanut", emoji: "\u{1F95C}", search: [/stray peanut/i], color: "orange" },
     { name: "Sun 2", emoji: "\u{1F31E}", search: [/Sun 2/i], color: "orange" },
-    { name: "Black Hole", emoji: "\u{26AB}", search: [/Black Hole/i], color: "gray" },
+    { name: "Black Hole", emoji: "\u{26AB}", search: [/Black Hole (swallowed|burped)/i], color: "gray" },
     { name: "Percolated", emoji: "\u{2615}", search: [/Percolated/], color: "brown" },
     { name: "Shelled", emoji: "\u{1F95C}", search: [/Shelled/], color: "orange" },
     { name: "Elsewhere", emoji: "\u{1F4A8}", search: [/Elsewhere/], color: "gray" },


### PR DESCRIPTION
The "IsGameUpdateImportant" regex got a little messier, but this was the easiest way of doing it.

The event picker was previously double counting the number of black holes which fired, because the message mentions the Black Hole Burping twice:

"The Black Hole swallowed the Runs and burped at the Breath Mints.
The Baltimore Crabs steal Leach Ingram for the remainder of the game.
The Black Hole burps!"