### PR TITLE
Fix for outcome picker with non-precalculated values

### DIFF
--- a/reblase/src/blaseball/outcome.ts
+++ b/reblase/src/blaseball/outcome.ts
@@ -14,6 +14,10 @@ interface OutcomeType {
 
 const shameOutcome: OutcomeType = { name: "Shame", emoji: "\u{1F7E3}", search: [], color: "purple" };
 
+export const calculatedOutcomeTypes: OutcomeType[] = [
+    shameOutcome,
+];
+
 export const outcomeTypes: OutcomeType[] = [
     shameOutcome,
     { name: "Party", emoji: "\u{1F389}", search: [/Partying/i], color: "gray" },

--- a/reblase/src/pages/SeasonPage.tsx
+++ b/reblase/src/pages/SeasonPage.tsx
@@ -10,7 +10,7 @@ import { useFights, useGameList, usePlayerTeamsList, useSimulation } from "../bl
 import { ChronGame } from "blaseball-lib/chronicler";
 import TeamPicker from "../components/elements/TeamPicker";
 import OutcomePicker from "../components/elements/OutcomePicker";
-import { getOutcomes } from "../blaseball/outcome";
+import { getOutcomes, calculatedOutcomeTypes } from "../blaseball/outcome";
 import WeatherPicker from "../components/elements/WeatherPicker";
 import Checkbox from "../components/elements/Checkbox";
 import { Link } from "react-router-dom";
@@ -96,7 +96,7 @@ function GamesListFetching(props: {
         started: !props.showFutureGames ? true : undefined,
         team: props.teams ? props.teams.join(",") : undefined,
         weather: props.weather ? props.weather.join(",") : undefined,
-        outcomes: props.outcomes ? true : undefined,
+        outcomes: props.outcomes && props.outcomes.every((x) => calculatedOutcomeTypes.map((x) => x.name).indexOf(x) === -1) ? true : undefined,
     });
 
     const { data: simData, error: simError, isLoading: simIsLoading } = useSimulation();


### PR DESCRIPTION
Currently, filtering by just "shame" on the season page only shows games which had outcomes in addition to ending in a shaming, because it was requesting only the filtered list from Chron. This has now been fixed to only request Chron perform the filtering if all outcomes are not calculated in javascript.