### PR TITLE
Black Hole events and Keyboard Nav on Season Page

### DIFF
--- a/blaseball-lib/games.ts
+++ b/blaseball-lib/games.ts
@@ -201,6 +201,7 @@ export function isGameUpdateImportant(update: string, scoreUpdate: string | null
         /evaded them/,
         /collected/,
         /Weather Report arrived from History/,
+        /Black Hole \(Black Hole\)/,
         /was Frozen/,
     ]) {
         if (pattern.test(update)) return true;

--- a/reblase/src/blaseball/outcome.ts
+++ b/reblase/src/blaseball/outcome.ts
@@ -44,6 +44,7 @@ export const outcomeTypes: OutcomeType[] = [
     { name: "Voicemail", emoji: "\u{260E}", search: [/was replaced by incoming Voicemail/], color: "gray" },
     { name: "Fifth Base", emoji: "\u{1F37D}", search: [/(took|placed) The Fifth Base/i], color: "gray" },
     { name: "Night Shift", emoji: "\u{1F4C7}", search: [/Night Shift/], color: "gray" },
+    { name: "Nullified", emoji: "\u{2B1B}", search: [/nullified/], color: "red" },
 ];
 
 export function getOutcomes(outcomes: string[], shame?: boolean, awayTeam?: string): Outcome[] {

--- a/reblase/src/components/gamelist/GameRow.tsx
+++ b/reblase/src/components/gamelist/GameRow.tsx
@@ -75,14 +75,11 @@ const Duration = React.memo(
         const arrow = props.topOfInning ? "\u25B2" : "\u25BC";
 
         return (
-            <Link
-                className="text-center text-sm tabular-nums text-gray-700 dark:text-gray-300"
-                to={`/game/${props.gameId}`}
-            >
+            <span className="text-center text-sm tabular-nums text-gray-700 dark:text-gray-300">
                 <span className="w-4 inline-block text-right mr-1">{props.inning + 1}</span>
                 <span className="text-xs pr-2 border-r border-gray-500 mr-2">{arrow}</span>
                 {duration}
-            </Link>
+            </span>
         );
     }
 );
@@ -232,7 +229,7 @@ export const GameRow = React.memo(
         return (
             <Link
                 to={`/game/${props.game.gameId}`}
-                className="flex flex-row px-2 py-2 border-b border-gray-300 dark:border-gray-700 space-x-2 items-baseline hover:bg-gray-200 dark-hover:bg-gray-800"
+                className="flex flex-row px-2 py-2 border-b border-gray-300 dark:border-gray-700 space-x-2 items-baseline hover:bg-gray-200 focus:bg-gray-200 dark-hover:bg-gray-800"
             >
                 <div className="contents md:hidden">
                     <TwoLineTeamScore home={home} away={away} />


### PR DESCRIPTION
Removes a link from the season page to cut number of tabs required to go from one game to another from 2 to 1. Also adds a focus rule.

Adds Black Hole (Black Hole) Nullifications to important and event lists.