### PR TITLE
Fix slow load time on bossfight/semicentennial pages

### DIFF
--- a/blaseball-lib/chronicler.ts
+++ b/blaseball-lib/chronicler.ts
@@ -60,14 +60,6 @@ export type FightUpdatesQuery = {
     page?: string;
 };
 
-export type SunSunPressureQuery = {
-    order?: "asc" | "desc";
-    count?: number;
-    after?: string;
-    before?: string;
-    page?: string;
-}
-
 export type TemporalUpdatesQuery = {
     order?: "asc" | "desc";
     count?: number;

--- a/blaseball-lib/chronicler.ts
+++ b/blaseball-lib/chronicler.ts
@@ -49,13 +49,13 @@ export type GameListQuery = {
 export type GameUpdatesQuery = {
     game: string;
     started: boolean;
-    after?: string;
+    after?: Timestamp;
     count?: number;
 };
 
 export type FightUpdatesQuery = {
     id: string;
-    after?: string;
+    after?: Timestamp;
     count?: number;
     page?: string;
 };
@@ -71,7 +71,8 @@ export type SunSunPressureQuery = {
 export type TemporalUpdatesQuery = {
     order?: "asc" | "desc";
     count?: number;
-    before?: string;
+    after?: Timestamp;
+    before?: Timestamp;
     page?: string;
 };
 

--- a/reblase/.env.offline.sample
+++ b/reblase/.env.offline.sample
@@ -1,0 +1,2 @@
+REACT_APP_SIBR_API=localhost:8000/vcr/
+REACT_APP_FEED_API=localhost:8000/vcr/feed/global

--- a/reblase/src/components/game/GameUpdateList.tsx
+++ b/reblase/src/components/game/GameUpdateList.tsx
@@ -150,6 +150,8 @@ interface GameUpdateListProps<TSecondary> {
     renderSecondary?: (update: SecondaryUpdate<TSecondary>) => React.ReactNode;
 }
 
+type Group<TSecondary> = { firstUpdate: GameOrFight, updates: GroupValue<TSecondary>[] }
+
 type GroupValue<TSecondary> =
     | { type: "primary"; data: GameOrFight }
     | { type: "secondary"; data: SecondaryUpdate<TSecondary> };
@@ -168,14 +170,17 @@ export function GameUpdateList<TSecondary = undefined>(props: GameUpdateListProp
     );
 
     const grouped = [];
+    let lastGroup: Group<TSecondary> | null = null;
+
     for (const elem of elements) {
         if (elem.type === "heading") {
-            grouped.push({
+            lastGroup = {
                 firstUpdate: elem.update,
                 updates: [] as GroupValue<TSecondary>[],
-            });
+            };
+            grouped.push(lastGroup);
         } else {
-            grouped[grouped.length - 1].updates.push({ type: "primary", data: elem.update });
+            lastGroup!.updates.push({ type: "primary", data: elem.update });
         }
     }
 
@@ -195,7 +200,7 @@ export function GameUpdateList<TSecondary = undefined>(props: GameUpdateListProp
             }
         }
 
-        grouped[grouped.length - 1].updates.push(...remaining.map((d) => ({ type: "secondary" as const, data: d })));
+        lastGroup!.updates.push(...remaining.map((d) => ({ type: "secondary" as const, data: d })));
     }
 
     const scrollTarget = window.location.hash.replace("#", "");

--- a/reblase/src/pages/BossfightPage.tsx
+++ b/reblase/src/pages/BossfightPage.tsx
@@ -1,6 +1,6 @@
 import { ChronFightUpdate, ChronTemporalUpdate } from "blaseball-lib/chronicler";
 import { BlaseballFight, BlaseballTemporal, DamageResult } from "blaseball-lib/models";
-import { useFightUpdates, useTemporal } from "blaseball/hooks";
+import { useFightUpdates, useTemporalForFight } from "blaseball/hooks";
 import { Loading } from "components/elements/Loading";
 import Twemoji from "components/elements/Twemoji";
 import { Container } from "components/layout/Container";
@@ -141,8 +141,8 @@ export default function BossfightPage() {
         id: fightId!,
     };
 
+    const { updates: temporalUpdates, error: temporalError, isLoading: temporalIsLoading } = useTemporalForFight(fightId);
     const { updates: fightUpdates, error: updatesError, isLoading } = useFightUpdates(query);
-    const { updates: temporalUpdates, error: temporalError, isLoading: temporalIsLoading } = useTemporal();
 
     if (updatesError || temporalError) return <Error>{(updatesError || temporalError).toString()}</Error>;
     if (isLoading || temporalIsLoading) return <Loading />;

--- a/reblase/src/pages/EventsPage.tsx
+++ b/reblase/src/pages/EventsPage.tsx
@@ -5,7 +5,7 @@ import { Container } from "../components/layout/Container";
 import { getOutcomes } from "../blaseball/outcome";
 import Error from "../components/elements/Error";
 import { Link } from "react-router-dom";
-import { useGameList, useTemporal, useFeedSeasonList } from "../blaseball/hooks";
+import { useGameList, useAllTemporal, useFeedSeasonList } from "../blaseball/hooks";
 import dayjs from "dayjs";
 import { displaySeason, displaySim, didSimHaveMultipleSeasons, GameTeam, getAwayTeam, getHomeTeam, STATIC_ID } from "blaseball-lib/games";
 import Twemoji from "components/elements/Twemoji";
@@ -161,7 +161,7 @@ const EventRow = ({ evt, feedSeasons }: { evt: BlaseEvent; feedSeasons: Blasebal
 
 export function EventsPage() {
     const { games, error, isLoading } = useGameList({ outcomes: true, order: "desc" });
-    const { updates: temporalUpdates, error: temporalError, isLoading: temporalIsLoading } = useTemporal();
+    const { updates: temporalUpdates, error: temporalError, isLoading: temporalIsLoading } = useAllTemporal();
     const { feedSeasonList, error: feedSeasonError, isLoading: feedSeasonIsLoading } = useFeedSeasonList();
 
     if (error || temporalError || feedSeasonError)

--- a/reblase/src/pages/EventsPage.tsx
+++ b/reblase/src/pages/EventsPage.tsx
@@ -215,7 +215,6 @@ export function EventsPage() {
         }
 
         if (lastTime && lastTime.diff(update.validFrom, "minute") > 5) {
-            console.log(`resetting: old=${lastTime.format()}, new=${update.validFrom}`);
             lastEvent = null;
         }
 

--- a/reblase/src/pages/SemiCentennialPage.tsx
+++ b/reblase/src/pages/SemiCentennialPage.tsx
@@ -1,6 +1,6 @@
 import { ChronGameUpdate, ChronTemporalUpdate, ChronSunSunPressure } from "blaseball-lib/chronicler";
 import { BlaseballGame, BlaseballTemporal, BlaseballSunSunPressure } from "blaseball-lib/models";
-import { useGameUpdates, useTemporal, useSunSunPressure } from "blaseball/hooks";
+import { useGameUpdates, useTemporalForGame, useSunSunPressureForGame } from "blaseball/hooks";
 import { Loading } from "components/elements/Loading";
 import Twemoji from "components/elements/Twemoji";
 import { Container } from "components/layout/Container";
@@ -32,7 +32,9 @@ const SemiCentennialHeading = (props: { firstEvt: ChronGameUpdate; lastEvtData: 
                 </h3>
             </Link>
 
-            <a href={`https://before.sibr.dev/_before/jump?redirect=%2Fleague&season=${props.lastEvtData.season}&time=${props.firstEvt.timestamp}`}>
+            <a
+                href={`https://before.sibr.dev/_before/jump?redirect=%2Fleague&season=${props.lastEvtData.season}&time=${props.firstEvt.timestamp}`}
+            >
                 <Tooltip placement="top" overlay={<span>Remember Before?</span>}>
                     <Twemoji emoji={"\u{1FA78}"} />
                 </Tooltip>
@@ -45,18 +47,21 @@ type SemiCentennialSecondary =
     | { type: "temporal"; data: BlaseballTemporal }
     | { type: "sunSun"; pressure: BlaseballSunSunPressure };
 
-function SemiCentennialUpdateList(
-    props: { 
-        gameUpdates: ChronGameUpdate[]; 
-        temporalUpdates: ChronTemporalUpdate[];
-        sunSunPressureUpdates: ChronSunSunPressure[] }) {
+function SemiCentennialUpdateList(props: {
+    gameUpdates: ChronGameUpdate[];
+    temporalUpdates: ChronTemporalUpdate[];
+    sunSunPressureUpdates: ChronSunSunPressure[];
+}) {
     const start = props.gameUpdates[0]?.timestamp;
     const end = props.gameUpdates[props.gameUpdates.length - 1]?.timestamp;
 
     const temporalSecondary = props.temporalUpdates
         .filter((upd) => upd.validFrom >= start && upd.validFrom < end)
         .filter((upd) => upd.data.doc?.zeta !== "")
-        .map((upd) => ({ timestamp: upd.validFrom, data: { type: "temporal", data: upd.data } as SemiCentennialSecondary }));
+        .map((upd) => ({
+            timestamp: upd.validFrom,
+            data: { type: "temporal", data: upd.data } as SemiCentennialSecondary,
+        }));
 
     const pressureSecondary = props.sunSunPressureUpdates
         .filter((upd) => upd.validFrom >= start && upd.validFrom < end)
@@ -73,7 +78,10 @@ function SemiCentennialUpdateList(
     const renderSecondary = (upd: SecondaryUpdate<SemiCentennialSecondary>) => {
         if (upd.data.type === "temporal") {
             return (
-                <div key={upd.timestamp + "_temporal"} className="p-2 border-b border-gray-300 dark:border-gray-700 TemporalRow">
+                <div
+                    key={upd.timestamp + "_temporal"}
+                    className="p-2 border-b border-gray-300 dark:border-gray-700 TemporalRow"
+                >
                     <span className="TemporalRow-Icon">
                         <Twemoji emoji={upd.data.data.doc?.gamma === 5 ? "\u{1F4DC}" : "\u{1FA99}"} />
                     </span>
@@ -82,7 +90,10 @@ function SemiCentennialUpdateList(
             );
         } else if (upd.data.type === "sunSun") {
             return (
-                <div key={upd.timestamp + "_pressure"} className="p-2 border-b border-gray-300 dark:border-gray-700 flex flex-row">
+                <div
+                    key={upd.timestamp + "_pressure"}
+                    className="p-2 border-b border-gray-300 dark:border-gray-700 flex flex-row"
+                >
                     <div>
                         <span className="font-semibold">
                             <Twemoji emoji={"\u{1F6A8}"} className="mr-2" />
@@ -91,23 +102,31 @@ function SemiCentennialUpdateList(
                     </div>
                     <div className="text-right flex-1">
                         <span className="text-gray-800 dark:text-gray-200 mr-1">
-                            <Twemoji emoji={"\u{1F31E}"} /> 
+                            <Twemoji emoji={"\u{1F31E}"} />
                             {Math.round((upd.data.pressure.current / upd.data.pressure.maximum) * 100).toLocaleString()}
                             %
                         </span>
                     </div>
-                    <div 
-                        style={{background: "linear-gradient(90deg, rgba(251,205,98,1) 0%, rgba(212,76,20,1) 100%",
-                                width: "100px"}}>
+                    <div
+                        style={{
+                            background: "linear-gradient(90deg, rgba(251,205,98,1) 0%, rgba(212,76,20,1) 100%",
+                            width: "100px",
+                        }}
+                    >
                         <div
                             className="progress-bar"
                             aria-valuenow={(upd.data.pressure.current / upd.data.pressure.maximum) * 100}
                             aria-valuemin={0}
                             aria-valuemax={100}
-                            style={
-                                {width: "".concat(Math.round((upd.data.pressure.current / upd.data.pressure.maximum) * 100).toLocaleString(), "%"),
-                                background: "linear-gradient(90deg, #10457f 0%, #2379a6 100%" }
-                            }
+                            style={{
+                                width: "".concat(
+                                    Math.round(
+                                        (upd.data.pressure.current / upd.data.pressure.maximum) * 100
+                                    ).toLocaleString(),
+                                    "%"
+                                ),
+                                background: "linear-gradient(90deg, #10457f 0%, #2379a6 100%",
+                            }}
                         />
                     </div>
                 </div>
@@ -115,7 +134,9 @@ function SemiCentennialUpdateList(
         }
     };
 
-    const secondary = [...temporalSecondary, ...pressureSecondary].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    const secondary = [...temporalSecondary, ...pressureSecondary].sort((a, b) =>
+        a.timestamp.localeCompare(b.timestamp)
+    );
 
     return (
         <GameUpdateList
@@ -134,15 +155,20 @@ export default function SemiCentennialPage() {
     const { gameId } = useParams<GamePageParams>();
 
     const query = {
-        game: gameId ?? "null",
-        started: true
+        game: gameId!,
+        started: true,
     };
 
     const { updates: gameUpdates, error: updatesError, isLoading } = useGameUpdates(query, false);
-    const { updates: temporalUpdates, error: temporalError, isLoading: temporalIsLoading } = useTemporal();
-    const { data: sunSunPressureUpdates, error: sunSunPressureError, isLoading: sunSunPressureIsLoading } = useSunSunPressure({});
+    const { updates: temporalUpdates, error: temporalError, isLoading: temporalIsLoading } = useTemporalForGame(gameId);
+    const {
+        data: sunSunPressureUpdates,
+        error: sunSunPressureError,
+        isLoading: sunSunPressureIsLoading,
+    } = useSunSunPressureForGame(gameId);
 
-    if (updatesError || temporalError || sunSunPressureError) return <Error>{(updatesError || temporalError || sunSunPressureError).toString()}</Error>;
+    if (updatesError || temporalError || sunSunPressureError)
+        return <Error>{(updatesError || temporalError || sunSunPressureError).toString()}</Error>;
     if (isLoading || temporalIsLoading || sunSunPressureIsLoading) return <Loading />;
 
     const first = gameUpdates[0];
@@ -150,9 +176,13 @@ export default function SemiCentennialPage() {
 
     return (
         <Container>
-             {last && <SemiCentennialHeading firstEvt={first} lastEvtData={last} />}
+            {last && <SemiCentennialHeading firstEvt={first} lastEvtData={last} />}
 
-             <SemiCentennialUpdateList gameUpdates={gameUpdates} temporalUpdates={temporalUpdates} sunSunPressureUpdates={sunSunPressureUpdates}/>
-         </Container>
-     );
+            <SemiCentennialUpdateList
+                gameUpdates={gameUpdates}
+                temporalUpdates={temporalUpdates}
+                sunSunPressureUpdates={sunSunPressureUpdates}
+            />
+        </Container>
+    );
 }


### PR DESCRIPTION
- Make explicit which string fields are timestamps
- Only request temporal and sunsun data for relevant time period
- Use cached lastGroup instead of indexing into grouped collection every time
- Remove debug logging
