### PR TITLE
update for season 2

### DIFF
--- a/blaseball-lib/chronicler.ts
+++ b/blaseball-lib/chronicler.ts
@@ -1,5 +1,5 @@
 import queryString from "query-string";
-import { GameID } from "./common";
+import { GameID, SeasonID } from "./common";
 import {
     BlaseballFight,
     BlaseballGame,
@@ -64,6 +64,7 @@ export type GameUpdatesQueryExperimental = {
 
 export type GameListQueryExperimental = {
     order?: "asc" | "desc";
+    season?: SeasonID;
 }
 
 export type QueryExperimental = {

--- a/blaseball-lib/games.ts
+++ b/blaseball-lib/games.ts
@@ -1,5 +1,5 @@
 import { PlayerID, TeamID } from "./common";
-import { BlaseballFeedSeasonList, BlaseballGame, BlaseballGameExperimental, BlaseballGameUpdateExperimental, CompositeGameState } from "./models";
+import { BlaseballFeedSeasonList, BlaseballGame, BlaseballGameUpdateExperimental } from "./models";
 
 export const STATIC_ID = "thisidisstaticyo";
 

--- a/blaseball-lib/models.ts
+++ b/blaseball-lib/models.ts
@@ -267,7 +267,7 @@ export interface BlaseballSimExperimental {
 export interface BlaseballSimDataExperimental {
     currentDay: number;
     currentSeasonId: SeasonID;
-    currentSeasonNumber: boolean; // this exists?! 
+    currentSeasonNumber: number; // this exists?! 
 }
 
 export interface DamageResult {

--- a/blaseball-lib/seasons.ts
+++ b/blaseball-lib/seasons.ts
@@ -1,0 +1,6 @@
+import { SeasonID } from "./common";
+
+export const returnedSeasons: Map<number, SeasonID> = new Map([
+    [0, "cd1b6714-f4de-4dfc-a030-851b3459d8d1"],
+    [1, "7af53acf-1fb9-40e8-96c7-ab8308a353f9"],
+]);

--- a/blaseball-lib/weather.ts
+++ b/blaseball-lib/weather.ts
@@ -1,3 +1,6 @@
+import { WeatherID } from "./common";
+import { BlaseballWeatherExperimental } from "./models";
+
 export interface WeatherType {
     id: number;
     name: string;
@@ -266,17 +269,6 @@ export const allWeatherTypes: WeatherType[] = [
 ];
 
 export function getWeather(id: number): WeatherType {
-    if (id === 3000){
-        return {
-            id: 3000,
-            name: "Horizon",
-            emoji: "\u{1F573}",
-            background: "#36001b",
-            color: "#ffc400",
-            forbidden: true,
-        };
-    }
-
     return (
         allWeatherTypes[id] ?? {
             id,
@@ -288,3 +280,65 @@ export function getWeather(id: number): WeatherType {
         }
     );
 }
+
+export const allExperimentalWeatherTypes: Map<WeatherID,WeatherType> = new Map([
+    ["8b260bb1-2b25-44af-9de4-2e97894b02f0", {
+        id: 0,
+        name: "Horizon",
+        emoji: "\u{1F573}",
+        background: "#36001b",
+        color: "#ffc400",
+        forbidden: false,
+    }],
+    ["1f2e2c8f-61c9-46ce-ad26-71d08a40c271", {
+        id: 0,
+        name: "Solar Eclipse (Red)",
+        emoji: "\u{1f534}",
+        background: "#67678a",
+        color: "#ff0000",
+        forbidden: true,
+    }],
+    ["1b36e28f-332e-47ef-b716-4894bd7db2ad", {
+        id: 0,
+        name: "Solar Eclipse (Gold)",
+        emoji: "\u{1F7E1}",
+        background: "#67678a",
+        color: "#000000",
+        forbidden: true,
+    }],
+    ["28757787-3d3d-4977-994a-4b76d3acc647", {
+        id: 0,
+        name: "Solar Eclipse (Silver)",
+        emoji: "\u{26AA}",
+        background: "#67678a",
+        color: "#000000",
+        forbidden: true,
+    }],
+    ["67631938-6e37-4ef0-97fd-5e92a95a0587", {
+        id: 0,
+        name: "Solar Eclipse (Blue)",
+        emoji: "\u{1f535}",
+        background: "#67678a",
+        color: "#00ff00",
+        forbidden: true,
+    }],
+]);
+
+
+export function getWeatherExperimental(gameWeather: BlaseballWeatherExperimental): WeatherType {
+    const weather = allExperimentalWeatherTypes.get(gameWeather.id);
+
+    if (weather) return weather;
+
+    console.error("no weather", gameWeather);
+
+    return {
+            id: -1,
+            name: "???",
+            emoji: "\u{2753}",
+            background: "#ffffff",
+            color: "#000000",
+            forbidden: true,
+        };
+}
+

--- a/reblase/src/blaseball/hooks.ts
+++ b/reblase/src/blaseball/hooks.ts
@@ -29,7 +29,6 @@ import {
     SunSunPressureResponse,
     ChronSunSunPressure,
     ChronFeedSeasonList,
-    Timestamp,
     GameUpdatesQueryExperimental,
     GameListQueryExperimental,
 } from "blaseball-lib/chronicler";
@@ -41,13 +40,11 @@ import {
 import { 
     BlaseballFeedEntry, 
     BlaseballFeedTemporalMetadata,
-    BlaseballGameBatchChangedState,
     BlaseballGameExperimental,
     BlaseballSimData,
     BlaseballSimExperimental,
     CompositeGameState
 } from "blaseball-lib/models";
-import { GameID } from "blaseball-lib/common";
 import dayjs from "dayjs";
 
 interface GameListHookReturn {
@@ -72,12 +69,15 @@ interface GameListExperimentalHookReturn {
     isLoading: boolean;
 }
 
-export function useGameListExperimental(query?: GameListQueryExperimental): GameListExperimentalHookReturn {
+export function useGameListExperimental(query: GameListQueryExperimental): GameListExperimentalHookReturn {
     const { data, error } = useSWR<ChronExperimental<BlaseballGameExperimental>>(chroniclerExperimentalApi.gameList(query ?? {}));
 
+    const allGames = data?.items.map((item) => item.data);
+    const filteredGames = allGames?.filter((game) => !query.season || game.seasonId == query.season);
+
     return {
-        games: data?.items.map((item) => item.data) ?? [],
-        error,
+        games: filteredGames ?? [],
+        error: error,
         isLoading: !data,
     };
 }
@@ -443,7 +443,7 @@ interface SimDataExperimentalHookReturn {
 }
 
 export function useSimulationExperimental(): SimDataExperimentalHookReturn {
-    const { data, error } = useSWR<ChronExperimental<BlaseballSimExperimental>>(chroniclerExperimentalApi.sim({order: "desc"}));
+    const { data, error } = useSWR<ChronExperimental<BlaseballSimExperimental>>(chroniclerExperimentalApi.sim({}));
 
     return {
         data: data?.items[0].data ?? null,

--- a/reblase/src/components/gamelist/DayTable.tsx
+++ b/reblase/src/components/gamelist/DayTable.tsx
@@ -82,6 +82,7 @@ export const DayTable = function DayTable(props: DayTableProps) {
 
 interface DayTableExperimentalProps {
     games: BlaseballGameExperimental[];
+    season: number,
     day: number;
     currentDay: number;
     showFutureWeather: boolean;
@@ -107,6 +108,7 @@ export const DayTableExperimental = function DayTable(props: DayTableExperimenta
                 return (
                     <GameRowExperimental
                         key={game.id}
+                        season={props.season}
                         game={game}
                         teams={props.teams}
                         showWeather={props.showFutureWeather || game.started}

--- a/reblase/src/components/gamelist/DayTable.tsx
+++ b/reblase/src/components/gamelist/DayTable.tsx
@@ -109,7 +109,7 @@ export const DayTableExperimental = function DayTable(props: DayTableExperimenta
                         key={game.id}
                         game={game}
                         teams={props.teams}
-                        showWeather={props.showFutureWeather || game.startTime !== null}
+                        showWeather={props.showFutureWeather || game.started}
                     />
                 );
             })}

--- a/reblase/src/components/gamelist/DayTable.tsx
+++ b/reblase/src/components/gamelist/DayTable.tsx
@@ -97,7 +97,7 @@ export const DayTableExperimental = function DayTable(props: DayTableExperimenta
         <>
             <div className="flex flex-row items-baseline mt-4 space-x-2">
                 <span className="font-semibold">
-                    {displaySimSeasonAndDayPlaintext(undefined, 0, props.day, undefined)}
+                    {displaySimSeasonAndDayPlaintext(undefined, props.season - 1, props.day, undefined)}
                 </span>
                 <span className="flex-1 text-right lg:text-left text-sm text-gray-700 dark:text-gray-300">
                     {timestamp?.format("YYYY-MM-DD HH:mm")}

--- a/reblase/src/components/gamelist/GameRow.tsx
+++ b/reblase/src/components/gamelist/GameRow.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { ChronFight, ChronGame } from "blaseball-lib/chronicler";
 import { getOutcomes, Outcome } from "../../blaseball/outcome";
-import { getWeather } from "blaseball-lib/weather";
-import { BlaseballFeedSeasonList, BlaseballGameExperimental, BlaseballTeam } from "blaseball-lib/models";
+import { getWeather, getWeatherExperimental } from "blaseball-lib/weather";
+import { BlaseballFeedSeasonList, BlaseballGameExperimental, BlaseballTeam, BlaseballWeatherExperimental } from "blaseball-lib/models";
 import Twemoji from "../elements/Twemoji";
 import { displaySimAndSeasonShorthand } from "blaseball-lib/games";
 
@@ -86,6 +86,16 @@ const Duration = React.memo(
 
 export const Weather = React.memo((props: { weather: number | null; className?: string }) => {
     const weather = getWeather(props.weather ?? -1) ?? { name: "???", emoji: "\u{2753}" };
+
+    return (
+        <Tooltip placement="top" overlay={<span>{weather.name}</span>}>
+            <Twemoji emoji={weather.emoji ?? "?"} className={props.className} />
+        </Tooltip>
+    );
+});
+
+export const WeatherExperimental = React.memo((props: { weather: BlaseballWeatherExperimental | null; className?: string }) => {
+    const weather = props.weather && getWeatherExperimental(props.weather) || { name: "???", emoji: "\u{2753}" };
 
     return (
         <Tooltip placement="top" overlay={<span>{weather.name}</span>}>
@@ -343,8 +353,7 @@ export const GameRowExperimental = React.memo(
             win: data.gameWinnerId == data.awayTeam.id,
         };
 
-        // hacks
-        const weather = props.showWeather ? 3000 : null;
+        const weather = props.showWeather ? data.weather : null;
 
         return (
             <Link
@@ -356,7 +365,7 @@ export const GameRowExperimental = React.memo(
 
                     <div className="flex flex-col justify-center items-end">
                         <div className="flex flex-row space-x-2">
-                            <Weather weather={weather} className="text-sm" />
+                            <WeatherExperimental weather={weather} className="text-sm" />
                             <SeasonDayExperimental
                                 day={data.day}
                                 className="text-right"
@@ -398,7 +407,7 @@ export const GameRowExperimental = React.memo(
                             inning={gameState?.inning ?? 0}
                             topOfInning={gameState?.topOfInning ?? false}
                         />
-                        <Weather weather={weather} />
+                        <WeatherExperimental weather={weather} />
                     </div>
                 </div>
             </Link>

--- a/reblase/src/components/gamelist/GameRow.tsx
+++ b/reblase/src/components/gamelist/GameRow.tsx
@@ -204,12 +204,13 @@ const SeasonDay = React.memo(
 
 const SeasonDayExperimental = React.memo(
     (props: {
+        season: number;
         day: number | string;
         className?: string;
     }) => {
         return (
             <div className={`text-sm font-semibold ${props.className}`}>
-                S1/{typeof props.day === "number" ? props.day + 1 : props.day}
+                S{props.season + 1}/{typeof props.day === "number" ? props.day + 1 : props.day}
             </div>
         );
     }
@@ -324,6 +325,7 @@ export const GameRow = React.memo(
 
 export const GameRowExperimental = React.memo(
     (props: {
+        season: number;
         game: BlaseballGameExperimental;
         teams: Record<string, BlaseballTeam>;
         showWeather: boolean;
@@ -367,6 +369,7 @@ export const GameRowExperimental = React.memo(
                         <div className="flex flex-row space-x-2">
                             <WeatherExperimental weather={weather} className="text-sm" />
                             <SeasonDayExperimental
+                                season={props.season - 1}
                                 day={data.day}
                                 className="text-right"
                             />
@@ -386,6 +389,7 @@ export const GameRowExperimental = React.memo(
 
                 <div className="hidden md:contents">
                     <SeasonDayExperimental
+                        season={props.season - 1}
                         day={data.day}
                         className="text-right"
                     />

--- a/reblase/src/pages/Home.tsx
+++ b/reblase/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import { TeamID } from "blaseball-lib/common";
 
 function SingleDayGamesList(props: {
     day: number;
+    season: number;
 }) {
     const { games, error, isLoading } = useGameListExperimental({order: "desc"});
     const { teams, error: teamError, isLoading: isLoadingTeams } = useTeamsList();
@@ -19,8 +20,6 @@ function SingleDayGamesList(props: {
     if (isLoading || isLoadingTeams) return <Loading />;
     const teamsMap: Record<TeamID, BlaseballTeam> = {};
     for (const team of teams) teamsMap[team.data.id!] = team.data;
-
-    console.log("all games", games);
 
     let gameRows: JSX.Element[] = [];
     games.forEach((game) => {
@@ -36,6 +35,7 @@ function SingleDayGamesList(props: {
         gameRows.push((          
             <GameRowExperimental
                 key={game.id}
+                season={props.season}
                 game={game}
                 teams={teamsMap}
                 showWeather={true}
@@ -44,8 +44,6 @@ function SingleDayGamesList(props: {
     });
 
     if (gameRows.length === 0) {
-        console.log("current day", props.day, "actual days", new Set(games.map((game) => game.day)));
-
         return (<h2>No Games</h2>);
     }
 
@@ -70,18 +68,25 @@ export function Home() {
             <div>
                 <h3 className="text-2xl font-semibold">Current games</h3>
 
+                {(sim.simData.currentDay < 0) ?
                 <h4 className="text-md text-gray-700 dark:text-gray-300 mb-2">
-                    Season 1, Day {sim.simData.currentDay + 1}
+                    Preseason for Season {sim.simData.currentSeasonNumber + 1}
                 </h4>
+                :
+                <>
+                    <h4 className="text-md text-gray-700 dark:text-gray-300 mb-2">
+                        Season {sim.simData.currentSeasonNumber + 1}, Day {sim.simData.currentDay + 1}
+                    </h4>
 
-                {sim && (
-                    <SingleDayGamesList day={sim.simData.currentDay} />
-                )}
+                    {sim && (
+                        <SingleDayGamesList season={sim.simData.currentSeasonNumber} day={sim.simData.currentDay} />
+                    )}
+                </>}
                 <Link className="block mt-2" to={
                     // we can worry about multiple seasons when there are multiple seasons
-                    `/experimental/season/1`
+                    `/experimental/season/${sim.simData.currentSeasonNumber + 1}`
                 }>
-                    <>View all Season 1 games &rarr;</>
+                    <>View all Season {sim.simData.currentSeasonNumber + 1} games &rarr;</>
                 </Link>
             </div>
         </Container>

--- a/reblase/src/pages/SeasonListPage.tsx
+++ b/reblase/src/pages/SeasonListPage.tsx
@@ -176,11 +176,14 @@ export function SeasonListPage() {
     const expansionEra = seasonsList.filter((x) => x.data.season >= 11);
     const disciplineEra = seasonsList.filter((x) => x.data.season >= 0 && x.data.season < 11);
     const exhibitions = seasonsList.filter((x) => x.data.season < 0);
-    const coronationEra: ExperimentalSeason[] = [{season: 0, seasonData: {start: "2023-01-09T17:00Z", end: "2023-01-14T02:00Z", name: "Season 1"}}];
+    const coronationEra: ExperimentalSeason[] = [
+        {season: 1, seasonData: {start: "2023-01-23T17:00Z", end: "2023-01-28T02:00Z", name: "Season 2"}},
+        {season: 0, seasonData: {start: "2023-01-09T17:00Z", end: "2023-01-14T02:00Z", name: "Season 1"}},
+    ];
 
     return (
         <Container className={"mt-4"}>
-            <h2 className="text-2xl font-semibold mb-2">The Return</h2>
+            <h2 className="text-2xl font-semibold mb-2">Coronation Era</h2>
             <SeasonGroupExperimental seasons={coronationEra}/>
 
             <h2 className="text-2xl font-semibold mb-2">

--- a/reblase/src/pages/SeasonPageExperimental.tsx
+++ b/reblase/src/pages/SeasonPageExperimental.tsx
@@ -67,6 +67,7 @@ const GamesList = React.memo(
 );
 
 function GamesListFetchingExperimental(props: {
+    games: BlaseballGameExperimental[];
     teams: string[] | null;
 
     complete: boolean;
@@ -75,9 +76,8 @@ function GamesListFetchingExperimental(props: {
 
     allTeams: BlaseballTeam[];
 }) {
-    const { games, error, isLoading } = useGameListExperimental();
-
     const { data: simData, error: simError, isLoading: simIsLoading } = useSimulationExperimental();
+    const games = props.games;
 
     const days = useMemo(() => {
         let gamesFiltered = games.filter((game) => {
@@ -178,6 +178,7 @@ export function SeasonPageExperimental() {
             <GamesListFetchingExperimental
                 teams={selectedTeams.length ? selectedTeams : null}
                 complete={complete}
+                games={games}
                 showFutureGames={showFutureGames}
                 showFutureWeather={showFutureWeather}
                 allTeams={teams.map((p) => p.data)}

--- a/reblase/src/pages/SeasonPageExperimental.tsx
+++ b/reblase/src/pages/SeasonPageExperimental.tsx
@@ -106,9 +106,16 @@ function GamesListFetchingExperimental(props: {
     );
 }
 
+interface SeasonPageParams {
+    season: string;
+}
+
 export function SeasonPageExperimental() {
     const location = useLocation();
 
+    const { season: seasonStr } = useParams<SeasonPageParams>();
+    const seasonNumber = parseInt(seasonStr);
+    const seasonId = returnedSeasons.get(seasonNumber - 1);
     const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
     const [showFutureGames, setShowFutureGames] = useState<boolean>(false);
 
@@ -118,7 +125,7 @@ export function SeasonPageExperimental() {
         games,
         error: gamesError,
         isLoading: isLoadingGames,
-    } = useGameListExperimental();
+    } = useGameListExperimental({season: seasonId});
 
     if (error || gamesError)
         return <Error>{(error || gamesError).toString()}</Error>;

--- a/reblase/src/pages/SeasonPageExperimental.tsx
+++ b/reblase/src/pages/SeasonPageExperimental.tsx
@@ -68,6 +68,8 @@ const GamesList = React.memo(
 
 function GamesListFetchingExperimental(props: {
     teams: string[] | null;
+
+    complete: boolean;
     showFutureGames: boolean;
 
     allTeams: BlaseballTeam[];
@@ -79,8 +81,10 @@ function GamesListFetchingExperimental(props: {
     const days = useMemo(() => {
         let gamesFiltered = games.filter((game) => {
             if (game.cancelled) return false;
-            // "show future games" is left as a problem for the reader
-            if (!game.started && !game.complete) return false;
+            if (!game.started) {
+                if (props.complete) return false;
+                if (!props.showFutureGames) return false;
+            }
             if (!props.teams) return true;
 
             return props.teams?.indexOf(game.awayTeam.id) !== -1 || props.teams.indexOf(game.homeTeam.id) !== -1;
@@ -116,6 +120,8 @@ export function SeasonPageExperimental() {
     const { season: seasonStr } = useParams<SeasonPageParams>();
     const seasonNumber = parseInt(seasonStr);
     const seasonId = returnedSeasons.get(seasonNumber - 1);
+    const complete = Math.max(...returnedSeasons.keys()) !== seasonNumber - 1;
+
     const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
     const [showFutureGames, setShowFutureGames] = useState<boolean>(false);
 
@@ -154,16 +160,19 @@ export function SeasonPageExperimental() {
                     />
                 </div>
 
+                {!complete &&
                 <div className="col-start-1">
                     <div className="font-semibold mb-1">Options</div>
                     <Checkbox value={showFutureGames} setValue={setShowFutureGames}>
                         Show future games
                     </Checkbox>
                 </div>
+                }
             </div>
 
             <GamesListFetchingExperimental
                 teams={selectedTeams.length ? selectedTeams : null}
+                complete={complete}
                 showFutureGames={showFutureGames}
                 allTeams={teams.map((p) => p.data)}
             />

--- a/reblase/src/pages/SeasonPageExperimental.tsx
+++ b/reblase/src/pages/SeasonPageExperimental.tsx
@@ -71,6 +71,7 @@ function GamesListFetchingExperimental(props: {
 
     complete: boolean;
     showFutureGames: boolean;
+    showFutureWeather: boolean;
 
     allTeams: BlaseballTeam[];
 }) {
@@ -103,7 +104,7 @@ function GamesListFetchingExperimental(props: {
             <GamesList
                 days={days}
                 teams={props.allTeams}
-                showFutureWeather={true}
+                showFutureWeather={props.showFutureWeather}
                 currentDay={currentDay}
             />
         </>
@@ -124,6 +125,7 @@ export function SeasonPageExperimental() {
 
     const [selectedTeams, setSelectedTeams] = useState<string[]>([]);
     const [showFutureGames, setShowFutureGames] = useState<boolean>(false);
+    const [showFutureWeather, setShowFutureWeather] = useState<boolean>(false);
 
     const { teams, error, isLoading: isLoadingTeams } = useTeamsList();
 
@@ -166,6 +168,9 @@ export function SeasonPageExperimental() {
                     <Checkbox value={showFutureGames} setValue={setShowFutureGames}>
                         Show future games
                     </Checkbox>
+                    <Checkbox value={showFutureWeather} setValue={setShowFutureWeather}>
+                        Show future weather
+                    </Checkbox>
                 </div>
                 }
             </div>
@@ -174,6 +179,7 @@ export function SeasonPageExperimental() {
                 teams={selectedTeams.length ? selectedTeams : null}
                 complete={complete}
                 showFutureGames={showFutureGames}
+                showFutureWeather={showFutureWeather}
                 allTeams={teams.map((p) => p.data)}
             />
         </Container>

--- a/reblase/src/pages/SeasonPageExperimental.tsx
+++ b/reblase/src/pages/SeasonPageExperimental.tsx
@@ -1,4 +1,4 @@
-﻿import { useLocation } from "react-router";
+﻿import { useLocation, useParams } from "react-router";
 import React, { useMemo, useState } from "react";
 
 import { DayTableExperimental } from "../components/gamelist/DayTable";
@@ -11,6 +11,7 @@ import Checkbox from "../components/elements/Checkbox";
 import { Link } from "react-router-dom";
 import { BlaseballFeedSeasonList, BlaseballGameExperimental, BlaseballTeam } from "blaseball-lib/models";
 import { PlayerID, SeasonID } from "blaseball-lib/common";
+import { returnedSeasons } from "blaseball-lib/seasons";
 
 type GameDay = { games: BlaseballGameExperimental[]; season: SeasonID; day: number };
 function groupByDay(games: BlaseballGameExperimental[]): GameDay[] {
@@ -38,6 +39,7 @@ function groupByDay(games: BlaseballGameExperimental[]): GameDay[] {
 
 const GamesList = React.memo(
     (props: {
+        season: number;
         days: GameDay[];
         teams: BlaseballTeam[];
         showFutureWeather: boolean;
@@ -53,6 +55,7 @@ const GamesList = React.memo(
                     return (
                         <DayTableExperimental
                             key={day}
+                            season={props.season}
                             day={day}
                             currentDay={props.currentDay}
                             games={games}
@@ -67,6 +70,7 @@ const GamesList = React.memo(
 );
 
 function GamesListFetchingExperimental(props: {
+    season: number;
     games: BlaseballGameExperimental[];
     teams: string[] | null;
 
@@ -94,14 +98,23 @@ function GamesListFetchingExperimental(props: {
         return groupByDay(gamesFiltered).reverse();
     }, [games, props.showFutureGames, props.teams]);
 
-    if (error || simError) return <Error>{(error || simError).toString()}</Error>;
-    if (isLoading || simIsLoading) return <Loading />;
+    if (days.length === 0) return (
+        <>
+            <span className="font-semibold mt-4 space-x-2">
+                No games which match current filters.
+            </span>
+        </>
+    );
+
+    if (simError) return <Error>{simError}</Error>;
+    if (simIsLoading) return <Loading />;
 
     const currentDay = simData?.simData.currentDay ?? 0;
 
     return (
         <>
             <GamesList
+                season={props.season}
                 days={days}
                 teams={props.allTeams}
                 showFutureWeather={props.showFutureWeather}
@@ -146,7 +159,7 @@ export function SeasonPageExperimental() {
             </p>
             <h2 className="text-2xl font-semibold mb-4">
                 <Link to={location.pathname}>
-                    Games in Season 1
+                    Games in Season {seasonNumber}
                 </Link>
             </h2>
 
@@ -176,11 +189,12 @@ export function SeasonPageExperimental() {
             </div>
 
             <GamesListFetchingExperimental
-                teams={selectedTeams.length ? selectedTeams : null}
+                season={seasonNumber}
                 complete={complete}
                 games={games}
                 showFutureGames={showFutureGames}
                 showFutureWeather={showFutureWeather}
+                teams={selectedTeams.length ? selectedTeams : null}
                 allTeams={teams.map((p) => p.data)}
             />
         </Container>

--- a/reblase/tsconfig.json
+++ b/reblase/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
- Allow games list to be filtered to single season
- Bump typescript target version to allow for using IterableIterator
- Make home page dynamic
- Add new weather
- Show new weather for experimental games
- Make shorthand season identifier not just say season 1
- "Handle" future games
- Fix current season number for sim model
- Display proper day in day table header
- Show future weather again
- Don't request games twice
- Show season 2 on season list page
- Idk leftover changes
