### PR TITLE
fix season index on game page

### DIFF
--- a/blaseball-lib/games.ts
+++ b/blaseball-lib/games.ts
@@ -274,6 +274,7 @@ export function isGameUpdateImportant(update: string, scoreUpdate: string | null
         /Black Hole \(Black Hole\)/,
         /was Frozen/,
         /\[ ?BURP ?\]/,
+        /Can't Lose! They join/,
     ]) {
         if (pattern.test(update)) return true;
     }

--- a/blaseball-lib/seasons.ts
+++ b/blaseball-lib/seasons.ts
@@ -4,3 +4,5 @@ export const returnedSeasons: Map<number, SeasonID> = new Map([
     [0, "cd1b6714-f4de-4dfc-a030-851b3459d8d1"],
     [1, "7af53acf-1fb9-40e8-96c7-ab8308a353f9"],
 ]);
+
+export const returnedSeasonsById: Map<SeasonID, number> = new Map(Array.from(returnedSeasons, entry => [entry[1], entry[0]]));

--- a/reblase/src/pages/GamePageExperimental.tsx
+++ b/reblase/src/pages/GamePageExperimental.tsx
@@ -11,6 +11,7 @@ import { displaySimAndSeasonPlaintext, displaySimSeasonAndDayPlaintext } from "b
 import { getWeatherExperimental } from "blaseball-lib/weather";
 import Twemoji from "components/elements/Twemoji";
 import { Loading } from "components/elements/Loading";
+import { returnedSeasonsById } from "blaseball-lib/seasons";
 
 interface PayloadProps {
     game: BlaseballGameExperimental,
@@ -20,16 +21,18 @@ const GameHeading = ({ game }: PayloadProps) => {
     const location = useLocation();
     const weather = getWeatherExperimental(game.weather);
 
+    const seasonNumber = returnedSeasonsById.get(game.seasonId) ?? NaN;
+
     return (
         <>
             <p className="mb-2">
-                <Link to={`/experimental/season/1`}>
-                    &larr; Back to {displaySimAndSeasonPlaintext(undefined, 0, null)}
+                <Link to={`/experimental/season/${seasonNumber + 1}`}>
+                    &larr; Back to {displaySimAndSeasonPlaintext(undefined, seasonNumber, null)}
                 </Link>
             </p>
             <Link to={location.pathname}>
                 <h2 className="text-3xl font-semibold">
-                    {displaySimSeasonAndDayPlaintext(undefined, 0, game.day, null)}
+                    {displaySimSeasonAndDayPlaintext(undefined, seasonNumber, game.day + 1, null)}
                 </h2>
             </Link>
 

--- a/reblase/src/pages/Home.tsx
+++ b/reblase/src/pages/Home.tsx
@@ -6,14 +6,17 @@ import { Container } from "../components/layout/Container";
 import { Loading } from "../components/elements/Loading";
 import { Link } from "react-router-dom";
 import { GameRowExperimental } from "../components/gamelist/GameRow";
-import { TeamID } from "blaseball-lib/common";
+import { SeasonID, TeamID } from "blaseball-lib/common";
 
 function SingleDayGamesList(props: {
     day: number;
-    season: number;
+    seasonNumber: number;
+    seasonId: SeasonID;
 }) {
     const { games, error, isLoading } = useGameListExperimental({order: "desc"});
     const { teams, error: teamError, isLoading: isLoadingTeams } = useTeamsList();
+
+    console.log("games", games);
 
     if (error) return <Error>{error.toString()}</Error>;
     if (teamError) return <Error>{teamError.toString()}</Error>;
@@ -23,19 +26,21 @@ function SingleDayGamesList(props: {
 
     let gameRows: JSX.Element[] = [];
     games.forEach((game) => {
-        if (game.day !== props.day){
+        if (game.day !== props.day || game.seasonId != props.seasonId){
             return;
         }
 
+        console.log("day does match", game.day, props.day);
+
         // the current value is guaranteed to be newer than this one, if it exists, because we're ordering in descending order.
-        if (gameRows.some((row) => row.key)) {
+        if (gameRows.some((row) => row.key == game.id)) {
             return;
-        }
+        }        
 
         gameRows.push((          
             <GameRowExperimental
                 key={game.id}
-                season={props.season}
+                season={props.seasonNumber}
                 game={game}
                 teams={teamsMap}
                 showWeather={true}
@@ -46,6 +51,8 @@ function SingleDayGamesList(props: {
     if (gameRows.length === 0) {
         return (<h2>No Games</h2>);
     }
+
+    console.log(gameRows);
 
     return (
         <div className="flex flex-col">
@@ -79,7 +86,10 @@ export function Home() {
                     </h4>
 
                     {sim && (
-                        <SingleDayGamesList season={sim.simData.currentSeasonNumber} day={sim.simData.currentDay} />
+                        <SingleDayGamesList
+                            seasonNumber={sim.simData.currentSeasonNumber}
+                            seasonId={sim.simData.currentSeasonId}
+                            day={sim.simData.currentDay} />
                     )}
                 </>}
                 <Link className="block mt-2" to={


### PR DESCRIPTION
- Get games autoupdating
- Show more than one game on home page
- Add "can't lose" effect to important
- Stop always pointing at season one for experimental games
